### PR TITLE
feat: add telemetry exporters for observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ import * as mcpcat from "mcpcat";
 
 const mcpServer = new Server({ name: "echo-mcp", version: "0.1.0" });
 
-// Register tools
-
-// NOTE: track() must be called *after* tools are setup
+// Track the server with MCPCat
 mcpcat.track(mcpServer, "proj_0000000");
+
+// Register your tools
 ```
 
 ### Identifying users

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@modelcontextprotocol/sdk": ">=1.3.1"
   },
   "dependencies": {
+    "@opentelemetry/otlp-transformer": "^0.203.0",
     "mcpcat-api": "0.1.3",
     "redact-pii": "3.4.0",
     "zod": "3.25.30"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      "@opentelemetry/otlp-transformer":
+        specifier: ^0.203.0
+        version: 0.203.0(@opentelemetry/api@1.9.0)
       mcpcat-api:
         specifier: 0.1.3
         version: 0.1.3
@@ -660,6 +663,81 @@ packages:
         integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
       }
     engines: { node: ">= 8" }
+
+  "@opentelemetry/api-logs@0.203.0":
+    resolution:
+      {
+        integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==,
+      }
+    engines: { node: ">=8.0.0" }
+
+  "@opentelemetry/api@1.9.0":
+    resolution:
+      {
+        integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==,
+      }
+    engines: { node: ">=8.0.0" }
+
+  "@opentelemetry/core@2.0.1":
+    resolution:
+      {
+        integrity: sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
+  "@opentelemetry/otlp-transformer@0.203.0":
+    resolution:
+      {
+        integrity: sha512-Y8I6GgoCna0qDQ2W6GCRtaF24SnvqvA8OfeTi7fqigD23u8Jpb4R5KFv/pRvrlGagcCLICMIyh9wiejp4TXu/A==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      "@opentelemetry/api": ^1.3.0
+
+  "@opentelemetry/resources@2.0.1":
+    resolution:
+      {
+        integrity: sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.3.0 <1.10.0"
+
+  "@opentelemetry/sdk-logs@0.203.0":
+    resolution:
+      {
+        integrity: sha512-vM2+rPq0Vi3nYA5akQD2f3QwossDnTDLvKbea6u/A2NZ3XDkPxMfo/PNrDoXhDUD/0pPo2CdH5ce/thn9K0kLw==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.4.0 <1.10.0"
+
+  "@opentelemetry/sdk-metrics@2.0.1":
+    resolution:
+      {
+        integrity: sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.9.0 <1.10.0"
+
+  "@opentelemetry/sdk-trace-base@2.0.1":
+    resolution:
+      {
+        integrity: sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.3.0 <1.10.0"
+
+  "@opentelemetry/semantic-conventions@1.36.0":
+    resolution:
+      {
+        integrity: sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==,
+      }
+    engines: { node: ">=14" }
 
   "@pkgjs/parseargs@0.11.0":
     resolution:
@@ -4062,10 +4140,10 @@ packages:
       }
     engines: { node: ">=10" }
 
-  zod-to-json-schema@3.24.6:
+  zod-to-json-schema@3.24.5:
     resolution:
       {
-        integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==,
+        integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==,
       }
     peerDependencies:
       zod: ^3.24.1
@@ -4453,7 +4531,7 @@ snapshots:
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
       zod: 3.25.30
-      zod-to-json-schema: 3.24.6(zod@3.25.30)
+      zod-to-json-schema: 3.24.5(zod@3.25.30)
     transitivePeerDependencies:
       - supports-color
 
@@ -4468,6 +4546,56 @@ snapshots:
     dependencies:
       "@nodelib/fs.scandir": 2.1.5
       fastq: 1.19.1
+
+  "@opentelemetry/api-logs@0.203.0":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+
+  "@opentelemetry/api@1.9.0": {}
+
+  "@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/semantic-conventions": 1.36.0
+
+  "@opentelemetry/otlp-transformer@0.203.0(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/api-logs": 0.203.0
+      "@opentelemetry/core": 2.0.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 2.0.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-logs": 0.203.0(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-metrics": 2.0.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/sdk-trace-base": 2.0.1(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.3
+
+  "@opentelemetry/resources@2.0.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 2.0.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/semantic-conventions": 1.36.0
+
+  "@opentelemetry/sdk-logs@0.203.0(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/api-logs": 0.203.0
+      "@opentelemetry/core": 2.0.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 2.0.1(@opentelemetry/api@1.9.0)
+
+  "@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 2.0.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 2.0.1(@opentelemetry/api@1.9.0)
+
+  "@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/core": 2.0.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/resources": 2.0.1(@opentelemetry/api@1.9.0)
+      "@opentelemetry/semantic-conventions": 1.36.0
+
+  "@opentelemetry/semantic-conventions@1.36.0": {}
 
   "@pkgjs/parseargs@0.11.0":
     optional: true
@@ -6513,7 +6641,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-to-json-schema@3.24.6(zod@3.25.30):
+  zod-to-json-schema@3.24.5(zod@3.25.30):
     dependencies:
       zod: 3.25.30
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,18 +18,21 @@ import { setupToolCallTracing } from "./modules/tracing.js";
 import { getSessionInfo, newSessionId } from "./modules/session.js";
 import { setServerTrackingData } from "./modules/internal.js";
 import { setupTracking } from "./modules/tracingV2.js";
+import { TelemetryManager } from "./modules/telemetry.js";
+import { setTelemetryManager } from "./modules/eventQueue.js";
 
 /**
  * Integrates MCPCat analytics into an MCP server to track tool usage patterns and user interactions.
  *
  * @param server - The MCP server instance to track. Must be a compatible MCP server implementation.
- * @param projectId - Your MCPCat project ID obtained from mcpcat.io when creating an account.
+ * @param projectId - Your MCPCat project ID obtained from mcpcat.io when creating an account. Pass null for telemetry-only mode.
  * @param options - Optional configuration to customize tracking behavior.
  * @param options.enableReportMissing - Adds a "get_more_tools" tool that allows LLMs to automatically report missing functionality.
  * @param options.enableTracing - Enables tracking of tool calls and usage patterns.
  * @param options.enableToolCallContext - Injects a "context" parameter to existing tools to capture user intent.
  * @param options.identify - Async function to identify users and attach custom data to their sessions.
  * @param options.redactSensitiveInformation - Function to redact sensitive data before sending to MCPCat.
+ * @param options.exporters - Configure telemetry exporters to send events to external systems (e.g., OpenTelemetry, Datadog).
  *
  * @returns The tracked server instance.
  *
@@ -80,23 +83,61 @@ import { setupTracking } from "./modules/tracingV2.js";
  *   }
  * });
  * ```
+ *
+ * @example
+ * ```typescript
+ * // Telemetry-only mode (no MCPCat account required)
+ * mcpcat.track(mcpServer, null, {
+ *   exporters: {
+ *     console: { type: "console" }
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Dual mode - send to both MCPCat and telemetry exporters
+ * mcpcat.track(mcpServer, "proj_abc123xyz", {
+ *   exporters: {
+ *     console: { type: "console" }
+ *   }
+ * });
+ * ```
  */
 function track(
   server: any,
-  projectId: string,
+  projectId: string | null,
   options: MCPCatOptions = {},
 ): any {
   try {
     const validatedServer = isCompatibleServerType(server);
+
     // For high-level servers, we need to pass the underlying server to some functions
     const lowLevelServer = (
       isHighLevelServer(validatedServer)
         ? (validatedServer as any).server
         : validatedServer
     ) as MCPServerLike;
+
+    // Initialize telemetry if exporters are configured
+    if (options.exporters) {
+      const telemetryManager = new TelemetryManager(options.exporters);
+      setTelemetryManager(telemetryManager);
+      writeToLog(
+        `Initialized telemetry with ${Object.keys(options.exporters).length} exporters`,
+      );
+    }
+
+    // If projectId is null and no exporters, warn the user
+    if (!projectId && !options.exporters) {
+      writeToLog(
+        "Warning: No projectId provided and no exporters configured. Events will not be sent anywhere.",
+      );
+    }
+
     const sessionInfo = getSessionInfo(lowLevelServer, undefined);
     const mcpcatData: MCPCatData = {
-      projectId,
+      projectId: projectId || "", // Use empty string for null projectId
       sessionId: newSessionId(),
       lastActivity: new Date(),
       identifiedSessions: new Map<string, UserIdentity>(),
@@ -140,7 +181,13 @@ function track(
   }
 }
 
-export type { MCPCatOptions, UserIdentity, RedactFunction } from "./types.js";
+export type {
+  MCPCatOptions,
+  UserIdentity,
+  RedactFunction,
+  ExporterConfig,
+  Exporter,
+} from "./types.js";
 
 export type IdentifyFunction = MCPCatOptions["identify"];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,14 +32,14 @@ import { setTelemetryManager } from "./modules/eventQueue.js";
  * @param options.enableToolCallContext - Injects a "context" parameter to existing tools to capture user intent.
  * @param options.identify - Async function to identify users and attach custom data to their sessions.
  * @param options.redactSensitiveInformation - Function to redact sensitive data before sending to MCPCat.
- * @param options.exporters - Configure telemetry exporters to send events to external systems (e.g., OpenTelemetry, Datadog).
+ * @param options.exporters - Configure telemetry exporters to send events to external systems. Available exporters:
+ *   - `otlp`: OpenTelemetry Protocol exporter (see {@link ../modules/exporters/otlp.OTLPExporter})
+ *   - `datadog`: Datadog APM exporter (see {@link ../modules/exporters/datadog.DatadogExporter})
+ *   - `sentry`: Sentry Monitoring exporter (see {@link ../modules/exporters/sentry.SentryExporter})
  *
  * @returns The tracked server instance.
  *
  * @remarks
- * **IMPORTANT**: The `track()` function must be called AFTER all tools have been registered on the server.
- * Calling it before tool registration will result in those tools not being tracked.
- *
  * Analytics data and debug information are logged to `~/mcpcat.log` since console logs interfere
  * with STDIO-based MCP servers.
  *
@@ -51,13 +51,13 @@ import { setTelemetryManager } from "./modules/eventQueue.js";
  *
  * const mcpServer = new Server({ name: "my-mcp-server", version: "1.0.0" });
  *
- * // Register your tools first
+ * // Track the server with MCPCat
+ * mcpcat.track(mcpServer, "proj_abc123xyz");
+ *
+ * // Register your tools
  * mcpServer.setRequestHandler(ListToolsRequestSchema, async () => ({
  *   tools: [{ name: "my_tool", description: "Does something useful" }]
  * }));
- *
- * // Then call track() after all tools are registered
- * mcpcat.track(mcpServer, "proj_abc123xyz");
  * ```
  *
  * @example
@@ -89,7 +89,10 @@ import { setTelemetryManager } from "./modules/eventQueue.js";
  * // Telemetry-only mode (no MCPCat account required)
  * mcpcat.track(mcpServer, null, {
  *   exporters: {
- *     console: { type: "console" }
+ *     otlp: {
+ *       type: "otlp",
+ *       endpoint: "http://localhost:4318/v1/traces"
+ *     }
  *   }
  * });
  * ```
@@ -99,7 +102,11 @@ import { setTelemetryManager } from "./modules/eventQueue.js";
  * // Dual mode - send to both MCPCat and telemetry exporters
  * mcpcat.track(mcpServer, "proj_abc123xyz", {
  *   exporters: {
- *     console: { type: "console" }
+ *     datadog: {
+ *       type: "datadog",
+ *       apiKey: process.env.DD_API_KEY,
+ *       site: "datadoghq.com"
+ *     }
  *   }
  * });
  * ```

--- a/src/modules/exporters/datadog.ts
+++ b/src/modules/exporters/datadog.ts
@@ -1,0 +1,203 @@
+import { Event, Exporter } from "../../types.js";
+import { writeToLog } from "../logging.js";
+
+export interface DatadogExporterConfig {
+  type: "datadog";
+  apiKey: string; // Required - Datadog API key
+  site: string; // Required - 'datadoghq.com', 'datadoghq.eu', etc.
+  service: string; // Required - MCP server name
+  env?: string; // Optional - environment
+}
+
+interface DatadogLog {
+  message: string;
+  service: string;
+  ddsource: string;
+  ddtags: string;
+  timestamp: number;
+  mcp: {
+    session_id?: string;
+    event_id?: string;
+    event_type?: string;
+    resource?: string;
+    duration_ms?: number;
+    user_intent?: string;
+    actor_id?: string;
+    actor_name?: string;
+    client_name?: string;
+    client_version?: string;
+    server_name?: string;
+    server_version?: string;
+    is_error?: boolean;
+    error?: any;
+  };
+}
+
+interface DatadogMetric {
+  metric: string;
+  type: "count" | "gauge" | "rate";
+  points: Array<[number, number]>;
+  tags?: string[];
+}
+
+export class DatadogExporter implements Exporter {
+  private logsUrl: string;
+  private metricsUrl: string;
+  private config: DatadogExporterConfig;
+
+  constructor(config: DatadogExporterConfig) {
+    this.config = config;
+
+    // Build API endpoints based on site
+    const site = config.site.replace(/^https?:\/\//, "").replace(/\/$/, "");
+    this.logsUrl = `https://http-intake.logs.${site}/api/v2/logs`;
+    this.metricsUrl = `https://api.${site}/api/v1/series`;
+  }
+
+  async export(event: Event): Promise<void> {
+    writeToLog("DatadogExporter: Sending event immediately to Datadog");
+
+    // Convert event to log and metrics
+    const log = this.eventToLog(event);
+    const metrics = this.eventToMetrics(event);
+
+    // Debug: Log the metrics payload
+    writeToLog(`DatadogExporter: Metrics URL: ${this.metricsUrl}`);
+    writeToLog(
+      `DatadogExporter: Metrics payload: ${JSON.stringify({ series: metrics })}`,
+    );
+
+    // Send logs with response checking
+    const logsPromise = fetch(this.logsUrl, {
+      method: "POST",
+      headers: {
+        "DD-API-KEY": this.config.apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([log]),
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          const errorBody = await response.text();
+          writeToLog(
+            `Datadog logs failed - Status: ${response.status}, Body: ${errorBody}`,
+          );
+        } else {
+          writeToLog(`Datadog logs success - Status: ${response.status}`);
+        }
+        return response;
+      })
+      .catch((err) => {
+        writeToLog(`Datadog logs network error: ${err}`);
+      });
+
+    // Send metrics with response checking
+    const metricsPromise = fetch(this.metricsUrl, {
+      method: "POST",
+      headers: {
+        "DD-API-KEY": this.config.apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ series: metrics }),
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          const errorBody = await response.text();
+          writeToLog(
+            `Datadog metrics failed - Status: ${response.status}, Body: ${errorBody}`,
+          );
+        } else {
+          const responseBody = await response.text();
+          writeToLog(
+            `Datadog metrics success - Status: ${response.status}, Body: ${responseBody}`,
+          );
+        }
+        return response;
+      })
+      .catch((err) => {
+        writeToLog(`Datadog metrics network error: ${err}`);
+      });
+
+    // Wait for both to complete
+    await Promise.all([logsPromise, metricsPromise]);
+  }
+
+  private eventToLog(event: Event): DatadogLog {
+    const tags: string[] = [];
+
+    // Add basic tags
+    if (this.config.env) tags.push(`env:${this.config.env}`);
+    if (event.eventType)
+      tags.push(`event_type:${event.eventType.replace(/\//g, ".")}`);
+    if (event.resourceName) tags.push(`resource:${event.resourceName}`);
+    if (event.isError) tags.push("error:true");
+
+    return {
+      message: `${event.eventType || "unknown"} - ${event.resourceName || "unknown"}`,
+      service: this.config.service,
+      ddsource: "mcpcat",
+      ddtags: tags.join(","),
+      timestamp: event.timestamp ? event.timestamp.getTime() : Date.now(),
+      mcp: {
+        session_id: event.sessionId,
+        event_id: event.id,
+        event_type: event.eventType,
+        resource: event.resourceName,
+        duration_ms: event.duration,
+        user_intent: event.userIntent,
+        actor_id: event.identifyActorGivenId,
+        actor_name: event.identifyActorName,
+        client_name: event.clientName,
+        client_version: event.clientVersion,
+        server_name: event.serverName,
+        server_version: event.serverVersion,
+        is_error: event.isError,
+        error: event.error,
+      },
+    };
+  }
+
+  private eventToMetrics(event: Event): DatadogMetric[] {
+    const metrics: DatadogMetric[] = [];
+    const timestamp = Math.floor(
+      (event.timestamp?.getTime() || Date.now()) / 1000,
+    );
+    const tags: string[] = [`service:${this.config.service}`];
+
+    // Add optional tags
+    if (this.config.env) tags.push(`env:${this.config.env}`);
+    if (event.eventType)
+      tags.push(`event_type:${event.eventType.replace(/\//g, ".")}`);
+    if (event.resourceName) tags.push(`resource:${event.resourceName}`);
+
+    // Event count metric
+    metrics.push({
+      metric: "mcp.events.count",
+      type: "count",
+      points: [[timestamp, 1]],
+      tags,
+    });
+
+    // Duration metric (only if duration exists)
+    if (event.duration) {
+      metrics.push({
+        metric: "mcp.event.duration",
+        type: "gauge",
+        points: [[timestamp, event.duration]],
+        tags,
+      });
+    }
+
+    // Error count metric
+    if (event.isError) {
+      metrics.push({
+        metric: "mcp.errors.count",
+        type: "count",
+        points: [[timestamp, 1]],
+        tags,
+      });
+    }
+
+    return metrics;
+  }
+}

--- a/src/modules/exporters/datadog.ts
+++ b/src/modules/exporters/datadog.ts
@@ -1,5 +1,6 @@
 import { Event, Exporter } from "../../types.js";
 import { writeToLog } from "../logging.js";
+import { traceContext } from "./trace-context.js";
 
 export interface DatadogExporterConfig {
   type: "datadog";
@@ -16,6 +17,10 @@ interface DatadogLog {
   ddtags: string;
   timestamp: number;
   status?: string;
+  dd?: {
+    trace_id: string;
+    span_id: string;
+  };
   error?: {
     message: string;
   };
@@ -143,6 +148,10 @@ export class DatadogExporter implements Exporter {
       ddtags: tags.join(","),
       timestamp: event.timestamp ? event.timestamp.getTime() : Date.now(),
       status: event.isError ? "error" : "info",
+      dd: {
+        trace_id: traceContext.getTraceId(event.sessionId),
+        span_id: traceContext.generateSpanId(),
+      },
       mcp: {
         session_id: event.sessionId,
         event_id: event.id,

--- a/src/modules/exporters/datadog.ts
+++ b/src/modules/exporters/datadog.ts
@@ -149,8 +149,8 @@ export class DatadogExporter implements Exporter {
       timestamp: event.timestamp ? event.timestamp.getTime() : Date.now(),
       status: event.isError ? "error" : "info",
       dd: {
-        trace_id: traceContext.getTraceId(event.sessionId),
-        span_id: traceContext.generateSpanId(),
+        trace_id: traceContext.getDatadogTraceId(event.sessionId),
+        span_id: traceContext.getDatadogSpanId(event.id),
       },
       mcp: {
         session_id: event.sessionId,

--- a/src/modules/exporters/otlp.ts
+++ b/src/modules/exporters/otlp.ts
@@ -92,7 +92,7 @@ export class OTLPExporter implements Exporter {
 
     return {
       traceId: traceContext.getTraceId(event.sessionId),
-      spanId: traceContext.generateSpanId(),
+      spanId: traceContext.getSpanId(event.id),
       name: event.eventType || "mcp.event",
       kind: 2, // SPAN_KIND_SERVER
       startTimeUnixNano: startTimeNanos.toString(),

--- a/src/modules/exporters/otlp.ts
+++ b/src/modules/exporters/otlp.ts
@@ -158,10 +158,26 @@ export class OTLPExporter implements Exporter {
   }
 
   private randomHex(length: number): string {
-    let result = "";
-    for (let i = 0; i < length; i++) {
-      result += Math.floor(Math.random() * 16).toString(16);
+    // Use crypto for better randomness and performance
+    const bytes = new Uint8Array(Math.ceil(length / 2));
+
+    // Use crypto.getRandomValues for browser compatibility
+    // or crypto.randomBytes in Node.js
+    if (
+      typeof globalThis.crypto !== "undefined" &&
+      globalThis.crypto.getRandomValues
+    ) {
+      globalThis.crypto.getRandomValues(bytes);
+    } else {
+      // Fallback to Node.js crypto module
+      const crypto = require("crypto");
+      const buffer = crypto.randomBytes(Math.ceil(length / 2));
+      bytes.set(buffer);
     }
-    return result;
+
+    return Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+      .slice(0, length);
   }
 }

--- a/src/modules/exporters/otlp.ts
+++ b/src/modules/exporters/otlp.ts
@@ -1,0 +1,167 @@
+import { Event, Exporter } from "../../types.js";
+import { writeToLog } from "../logging.js";
+
+export interface OTLPExporterConfig {
+  type: "otlp";
+  endpoint?: string;
+  protocol?: "http/protobuf" | "grpc";
+  headers?: Record<string, string>;
+  compression?: "gzip" | "none";
+}
+
+export class OTLPExporter implements Exporter {
+  private endpoint: string;
+  private headers: Record<string, string>;
+  private protocol: string;
+
+  constructor(config: OTLPExporterConfig) {
+    // Default to HTTP protocol on localhost
+    this.protocol = config.protocol || "http/protobuf";
+    this.endpoint =
+      config.endpoint ||
+      (this.protocol === "grpc"
+        ? "http://localhost:4317"
+        : "http://localhost:4318/v1/traces");
+    this.headers = {
+      "Content-Type": "application/json", // Using JSON for now for easier debugging
+      ...config.headers,
+    };
+  }
+
+  async export(event: Event): Promise<void> {
+    try {
+      // Convert MCPCat event to OTLP trace format
+      const span = this.convertToOTLPSpan(event);
+
+      // Create OTLP JSON format
+      const otlpRequest = {
+        resourceSpans: [
+          {
+            resource: {
+              attributes: [
+                {
+                  key: "service.name",
+                  value: { stringValue: event.serverName || "mcp-server" },
+                },
+                {
+                  key: "service.version",
+                  value: { stringValue: event.serverVersion || "unknown" },
+                },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: {
+                  name: "mcpcat",
+                  version: event.mcpcatVersion || "0.1.0",
+                },
+                spans: [span],
+              },
+            ],
+          },
+        ],
+      };
+
+      // Use JSON format for now
+      const body = JSON.stringify(otlpRequest);
+
+      // Use fetch to send the data
+      const response = await fetch(this.endpoint, {
+        method: "POST",
+        headers: this.headers,
+        body,
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `OTLP export failed: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      writeToLog(`Successfully exported event to OTLP: ${event.id}`);
+    } catch (error) {
+      throw new Error(`OTLP export error: ${error}`);
+    }
+  }
+
+  private convertToOTLPSpan(event: Event): any {
+    const startTimeNanos = event.timestamp
+      ? BigInt(event.timestamp.getTime()) * BigInt(1_000_000)
+      : BigInt(Date.now()) * BigInt(1_000_000);
+
+    const endTimeNanos = event.duration
+      ? startTimeNanos + BigInt(event.duration) * BigInt(1_000_000)
+      : startTimeNanos;
+
+    return {
+      traceId: this.generateTraceId(event.sessionId),
+      spanId: this.generateSpanId(event.id),
+      name: event.eventType || "mcp.event",
+      kind: 2, // SPAN_KIND_SERVER
+      startTimeUnixNano: startTimeNanos.toString(),
+      endTimeUnixNano: endTimeNanos.toString(),
+      attributes: [
+        {
+          key: "mcp.event_type",
+          value: { stringValue: event.eventType || "" },
+        },
+        {
+          key: "mcp.session_id",
+          value: { stringValue: event.sessionId || "" },
+        },
+        {
+          key: "mcp.project_id",
+          value: { stringValue: event.projectId || "" },
+        },
+        {
+          key: "mcp.resource_name",
+          value: { stringValue: event.resourceName || "" },
+        },
+        {
+          key: "mcp.actor_id",
+          value: { stringValue: event.identifyActorGivenId || "anonymous" },
+        },
+        {
+          key: "mcp.client_name",
+          value: { stringValue: event.clientName || "" },
+        },
+        {
+          key: "mcp.client_version",
+          value: { stringValue: event.clientVersion || "" },
+        },
+      ].filter((attr) => attr.value.stringValue), // Remove empty attributes
+      status: {
+        code: event.isError ? 2 : 1, // ERROR : OK
+      },
+    };
+  }
+
+  private generateTraceId(sessionId?: string): string {
+    // Generate a 32-character hex string (128 bits)
+    if (sessionId) {
+      // Use session ID as base for consistent trace grouping
+      return this.padHex(sessionId.replace(/[^a-f0-9]/gi, ""), 32);
+    }
+    return this.randomHex(32);
+  }
+
+  private generateSpanId(eventId?: string): string {
+    // Generate a 16-character hex string (64 bits)
+    if (eventId) {
+      return this.padHex(eventId.replace(/[^a-f0-9]/gi, ""), 16);
+    }
+    return this.randomHex(16);
+  }
+
+  private padHex(str: string, length: number): string {
+    return str.padStart(length, "0").slice(-length);
+  }
+
+  private randomHex(length: number): string {
+    let result = "";
+    for (let i = 0; i < length; i++) {
+      result += Math.floor(Math.random() * 16).toString(16);
+    }
+    return result;
+  }
+}

--- a/src/modules/exporters/otlp.ts
+++ b/src/modules/exporters/otlp.ts
@@ -4,7 +4,7 @@ import { traceContext } from "./trace-context.js";
 
 export interface OTLPExporterConfig {
   type: "otlp";
-  endpoint?: string;
+  endpoint: string;
   protocol?: "http/protobuf" | "grpc";
   headers?: Record<string, string>;
   compression?: "gzip" | "none";
@@ -18,11 +18,7 @@ export class OTLPExporter implements Exporter {
   constructor(config: OTLPExporterConfig) {
     // Default to HTTP protocol on localhost
     this.protocol = config.protocol || "http/protobuf";
-    this.endpoint =
-      config.endpoint ||
-      (this.protocol === "grpc"
-        ? "http://localhost:4317"
-        : "http://localhost:4318/v1/traces");
+    this.endpoint = config.endpoint;
     this.headers = {
       "Content-Type": "application/json", // Using JSON for now for easier debugging
       ...config.headers,
@@ -54,7 +50,7 @@ export class OTLPExporter implements Exporter {
               {
                 scope: {
                   name: "mcpcat",
-                  version: event.mcpcatVersion || "0.1.0",
+                  version: event.mcpcatVersion || "unknown",
                 },
                 spans: [span],
               },

--- a/src/modules/exporters/sentry.ts
+++ b/src/modules/exporters/sentry.ts
@@ -1,0 +1,270 @@
+import { Event, Exporter } from "../../types.js";
+import { writeToLog } from "../logging.js";
+
+export interface SentryExporterConfig {
+  type: "sentry";
+  dsn: string;
+  environment?: string;
+  release?: string;
+}
+
+interface ParsedDSN {
+  protocol: string;
+  publicKey: string;
+  host: string;
+  port?: string;
+  path: string;
+  projectId: string;
+}
+
+interface SentryTransaction {
+  type: "transaction";
+  event_id: string;
+  timestamp: number;
+  start_timestamp: number;
+  transaction: string;
+  contexts: {
+    trace: {
+      trace_id: string;
+      span_id: string;
+      op: string;
+      status?: "ok" | "internal_error";
+    };
+  };
+  spans?: Array<{
+    span_id: string;
+    trace_id: string;
+    parent_span_id?: string;
+    op: string;
+    description?: string;
+    start_timestamp: number;
+    timestamp: number;
+    status?: "ok" | "internal_error";
+  }>;
+  tags?: Record<string, string>;
+  extra?: Record<string, any>;
+}
+
+export class SentryExporter implements Exporter {
+  private endpoint: string;
+  private authHeader: string;
+  private config: SentryExporterConfig;
+  private parsedDSN: ParsedDSN;
+
+  constructor(config: SentryExporterConfig) {
+    this.config = config;
+    this.parsedDSN = this.parseDSN(config.dsn);
+
+    // Build envelope endpoint
+    this.endpoint = `${this.parsedDSN.protocol}://${this.parsedDSN.host}${
+      this.parsedDSN.port ? `:${this.parsedDSN.port}` : ""
+    }${this.parsedDSN.path}/api/${this.parsedDSN.projectId}/envelope/`;
+
+    // Build auth header
+    this.authHeader = `Sentry sentry_version=7, sentry_client=mcpcat/1.0.0, sentry_key=${this.parsedDSN.publicKey}`;
+
+    writeToLog(`SentryExporter: Initialized with endpoint ${this.endpoint}`);
+  }
+
+  private parseDSN(dsn: string): ParsedDSN {
+    // DSN format: protocol://publicKey@host[:port]/path/projectId
+    const regex = /^(https?):\/\/([a-f0-9]+)@([\w.-]+)(:\d+)?(\/.*)?\/(\d+)$/;
+    const match = dsn.match(regex);
+
+    if (!match) {
+      throw new Error(`Invalid Sentry DSN: ${dsn}`);
+    }
+
+    return {
+      protocol: match[1],
+      publicKey: match[2],
+      host: match[3],
+      port: match[4]?.substring(1), // Remove leading ':'
+      path: match[5] || "",
+      projectId: match[6],
+    };
+  }
+
+  async export(event: Event): Promise<void> {
+    try {
+      const transaction = this.eventToTransaction(event);
+      const envelope = this.createEnvelope(transaction);
+
+      writeToLog(
+        `SentryExporter: Sending transaction ${transaction.event_id} to Sentry`,
+      );
+
+      const response = await fetch(this.endpoint, {
+        method: "POST",
+        headers: {
+          "X-Sentry-Auth": this.authHeader,
+          "Content-Type": "application/x-sentry-envelope",
+        },
+        body: envelope,
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        writeToLog(
+          `Sentry export failed - Status: ${response.status}, Body: ${errorBody}`,
+        );
+      } else {
+        writeToLog(`Sentry export success - Event: ${event.id}`);
+      }
+    } catch (error) {
+      writeToLog(`Sentry export error: ${error}`);
+    }
+  }
+
+  private eventToTransaction(event: Event): SentryTransaction {
+    // Calculate timestamps
+    const endTimestamp = event.timestamp
+      ? new Date(event.timestamp).getTime() / 1000
+      : Date.now() / 1000;
+
+    const startTimestamp = event.duration
+      ? endTimestamp - event.duration / 1000
+      : endTimestamp;
+
+    const traceId = this.generateTraceId(event.sessionId);
+    const spanId = this.generateSpanId(event.id);
+
+    // Build transaction name
+    const transactionName = event.resourceName
+      ? `${event.eventType || "mcp"} - ${event.resourceName}`
+      : event.eventType || "mcp.event";
+
+    const transaction: SentryTransaction = {
+      type: "transaction",
+      event_id: this.generateEventId(event.id),
+      timestamp: endTimestamp,
+      start_timestamp: startTimestamp,
+      transaction: transactionName,
+      contexts: {
+        trace: {
+          trace_id: traceId,
+          span_id: spanId,
+          op: event.eventType || "mcp.event",
+          status: event.isError ? "internal_error" : "ok",
+        },
+      },
+      tags: this.buildTags(event),
+      extra: this.buildExtra(event),
+    };
+
+    return transaction;
+  }
+
+  private buildTags(event: Event): Record<string, string> {
+    const tags: Record<string, string> = {};
+
+    if (this.config.environment) tags.environment = this.config.environment;
+    if (this.config.release) tags.release = this.config.release;
+    if (event.eventType) tags.event_type = event.eventType;
+    if (event.resourceName) tags.resource = event.resourceName;
+    if (event.serverName) tags.server_name = event.serverName;
+    if (event.clientName) tags.client_name = event.clientName;
+    if (event.identifyActorGivenId) tags.actor_id = event.identifyActorGivenId;
+
+    return tags;
+  }
+
+  private buildExtra(event: Event): Record<string, any> {
+    const extra: Record<string, any> = {};
+
+    if (event.sessionId) extra.session_id = event.sessionId;
+    if (event.projectId) extra.project_id = event.projectId;
+    if (event.userIntent) extra.user_intent = event.userIntent;
+    if (event.identifyActorName) extra.actor_name = event.identifyActorName;
+    if (event.serverVersion) extra.server_version = event.serverVersion;
+    if (event.clientVersion) extra.client_version = event.clientVersion;
+    if (event.duration !== undefined) extra.duration_ms = event.duration;
+    if (event.error) extra.error = event.error;
+
+    return extra;
+  }
+
+  private createEnvelope(transaction: SentryTransaction): string {
+    // Envelope header
+    const envelopeHeader = {
+      event_id: transaction.event_id,
+      sent_at: new Date().toISOString(),
+    };
+
+    // Item header for transaction
+    const itemHeader = {
+      type: "transaction",
+    };
+
+    // Build envelope (newline-separated JSON)
+    return [
+      JSON.stringify(envelopeHeader),
+      JSON.stringify(itemHeader),
+      JSON.stringify(transaction),
+    ].join("\n");
+  }
+
+  private generateEventId(eventId?: string): string {
+    // Sentry expects 32 character hex string without dashes
+    if (eventId) {
+      return this.toHex32(eventId);
+    }
+    return this.randomHex(32);
+  }
+
+  private generateTraceId(sessionId?: string): string {
+    // 32 character hex string for trace ID
+    if (sessionId) {
+      return this.toHex32(sessionId);
+    }
+    return this.randomHex(32);
+  }
+
+  private generateSpanId(eventId?: string): string {
+    // 16 character hex string for span ID
+    if (eventId) {
+      return this.toHex16(eventId);
+    }
+    return this.randomHex(16);
+  }
+
+  private toHex32(str: string): string {
+    // Convert string to 32 character hex
+    const clean = str.replace(/[^a-f0-9]/gi, "").toLowerCase();
+    if (clean.length >= 32) {
+      return clean.substring(0, 32);
+    }
+    // Pad with deterministic hash if too short
+    return (clean + this.simpleHash(str)).padEnd(32, "0").substring(0, 32);
+  }
+
+  private toHex16(str: string): string {
+    // Convert string to 16 character hex
+    const clean = str.replace(/[^a-f0-9]/gi, "").toLowerCase();
+    if (clean.length >= 16) {
+      return clean.substring(0, 16);
+    }
+    // Pad with deterministic hash if too short
+    return (clean + this.simpleHash(str)).padEnd(16, "0").substring(0, 16);
+  }
+
+  private simpleHash(str: string): string {
+    // Simple deterministic hash for padding
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+    return Math.abs(hash).toString(16);
+  }
+
+  private randomHex(length: number): string {
+    let result = "";
+    const chars = "0123456789abcdef";
+    for (let i = 0; i < length; i++) {
+      result += chars[Math.floor(Math.random() * 16)];
+    }
+    return result;
+  }
+}

--- a/src/modules/exporters/trace-context.ts
+++ b/src/modules/exporters/trace-context.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared trace context management for all exporters.
+ * Maintains one trace ID per session for proper observability tool correlation.
+ */
+
+class TraceContext {
+  private sessionTraces = new Map<string, string>();
+
+  /**
+   * Get or create a trace ID for a session.
+   * Returns the same trace ID for all events in a session.
+   */
+  getTraceId(sessionId?: string): string {
+    if (!sessionId) {
+      // No session, return random trace ID
+      return this.randomHex(32);
+    }
+
+    if (!this.sessionTraces.has(sessionId)) {
+      // First event in session, create new trace ID
+      this.sessionTraces.set(sessionId, this.randomHex(32));
+    }
+
+    return this.sessionTraces.get(sessionId)!;
+  }
+
+  /**
+   * Generate a random span ID.
+   * Always returns a new random ID for uniqueness.
+   */
+  generateSpanId(): string {
+    return this.randomHex(16);
+  }
+
+  /**
+   * Generate random hex string of specified length.
+   * Uses Math.random() for performance (same as OpenTelemetry).
+   */
+  private randomHex(length: number): string {
+    const chars = "0123456789abcdef";
+    let result = "";
+    for (let i = 0; i < length; i++) {
+      result += chars[Math.floor(Math.random() * 16)];
+    }
+    return result;
+  }
+}
+
+// Export singleton instance
+export const traceContext = new TraceContext();

--- a/src/modules/exporters/trace-context.ts
+++ b/src/modules/exporters/trace-context.ts
@@ -1,50 +1,34 @@
-/**
- * Shared trace context management for all exporters.
- * Maintains one trace ID per session for proper observability tool correlation.
- */
+import { createHash, randomBytes } from "crypto";
 
 class TraceContext {
-  private sessionTraces = new Map<string, string>();
-
-  /**
-   * Get or create a trace ID for a session.
-   * Returns the same trace ID for all events in a session.
-   */
   getTraceId(sessionId?: string): string {
     if (!sessionId) {
-      // No session, return random trace ID
-      return this.randomHex(32);
+      return randomBytes(16).toString("hex");
     }
 
-    if (!this.sessionTraces.has(sessionId)) {
-      // First event in session, create new trace ID
-      this.sessionTraces.set(sessionId, this.randomHex(32));
-    }
-
-    return this.sessionTraces.get(sessionId)!;
+    return createHash("sha256")
+      .update(sessionId)
+      .digest("hex")
+      .substring(0, 32);
   }
 
-  /**
-   * Generate a random span ID.
-   * Always returns a new random ID for uniqueness.
-   */
-  generateSpanId(): string {
-    return this.randomHex(16);
+  getSpanId(eventId?: string): string {
+    if (!eventId) {
+      return randomBytes(8).toString("hex");
+    }
+
+    return createHash("sha256").update(eventId).digest("hex").substring(0, 16);
   }
 
-  /**
-   * Generate random hex string of specified length.
-   * Uses Math.random() for performance (same as OpenTelemetry).
-   */
-  private randomHex(length: number): string {
-    const chars = "0123456789abcdef";
-    let result = "";
-    for (let i = 0; i < length; i++) {
-      result += chars[Math.floor(Math.random() * 16)];
-    }
-    return result;
+  getDatadogTraceId(sessionId?: string): string {
+    const hex = this.getTraceId(sessionId);
+    return BigInt("0x" + hex.substring(16, 32)).toString();
+  }
+
+  getDatadogSpanId(eventId?: string): string {
+    const hex = this.getSpanId(eventId);
+    return BigInt("0x" + hex).toString();
   }
 }
 
-// Export singleton instance
 export const traceContext = new TraceContext();

--- a/src/modules/telemetry.ts
+++ b/src/modules/telemetry.ts
@@ -1,0 +1,66 @@
+import { Event, Exporter, ExporterConfig } from "../types.js";
+import { writeToLog } from "./logging.js";
+import { OTLPExporter } from "./exporters/otlp.js";
+import { DatadogExporter } from "./exporters/datadog.js";
+import { SentryExporter } from "./exporters/sentry.js";
+
+export class TelemetryManager {
+  private exporters: Map<string, Exporter> = new Map();
+
+  constructor(exporterConfigs?: Record<string, ExporterConfig>) {
+    if (!exporterConfigs) return;
+
+    for (const [name, config] of Object.entries(exporterConfigs)) {
+      try {
+        const exporter = this.createExporter(name, config);
+        if (exporter) {
+          this.exporters.set(name, exporter);
+          writeToLog(`Initialized telemetry exporter: ${name}`);
+        }
+      } catch (error) {
+        writeToLog(`Failed to initialize exporter ${name}: ${error}`);
+      }
+    }
+  }
+
+  private createExporter(
+    name: string,
+    config: ExporterConfig,
+  ): Exporter | null {
+    switch (config.type) {
+      case "console":
+        return new ConsoleExporter();
+      case "otlp":
+        return new OTLPExporter(config as any);
+      case "datadog":
+        return new DatadogExporter(config as any);
+      case "sentry":
+        return new SentryExporter(config as any);
+      default:
+        writeToLog(`Unknown exporter type: ${config.type}`);
+        return null;
+    }
+  }
+
+  async export(event: Event): Promise<void> {
+    if (this.exporters.size === 0) return;
+
+    // Fire-and-forget pattern for each exporter
+    for (const [name, exporter] of this.exporters) {
+      exporter.export(event).catch((error) => {
+        writeToLog(`Telemetry export failed for ${name}: ${error}`);
+      });
+    }
+  }
+
+  getExporterCount(): number {
+    return this.exporters.size;
+  }
+}
+
+// Simple console exporter for testing
+class ConsoleExporter implements Exporter {
+  async export(event: Event): Promise<void> {
+    console.error("[MCPCat Telemetry]", JSON.stringify(event, null, 2));
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types";
-import { PublishEventRequest } from "mcpcat-api";
 
 export interface MCPCatOptions {
   enableReportMissing?: boolean;
@@ -10,6 +9,7 @@ export interface MCPCatOptions {
     extra?: CompatibleRequestHandlerExtra,
   ) => Promise<UserIdentity | null>;
   redactSensitiveInformation?: RedactFunction;
+  exporters?: Record<string, ExporterConfig>;
 }
 
 export type ToolCallback =
@@ -30,14 +30,62 @@ export type RegisteredTool = {
 
 export type RedactFunction = (text: string) => Promise<string>;
 
+export interface ExporterConfig {
+  type: string;
+  [key: string]: any;
+}
+
+export interface Exporter {
+  export(event: Event): Promise<void>;
+}
+
 export enum MCPCatIDPrefixes {
   Session = "ses",
   Event = "evt",
 }
 
-export interface Event extends PublishEventRequest {}
+export interface Event {
+  // Core identification
+  id: string;
+  sessionId: string;
+  projectId?: string; // Optional for telemetry-only mode
 
-export interface UnredactedEvent extends Event {
+  // Event metadata
+  eventType: string; // Changed from enum to string for flexibility
+  timestamp: Date;
+  duration?: number;
+
+  // Session context (from SessionInfo)
+  ipAddress?: string;
+  sdkLanguage?: string;
+  mcpcatVersion?: string;
+  serverName?: string;
+  serverVersion?: string;
+  clientName?: string;
+  clientVersion?: string;
+
+  // Actor/identity information
+  identifyActorGivenId?: string;
+  identifyActorName?: string;
+  identifyActorData?: object;
+
+  // Event-specific data
+  resourceName?: string; // Tool/resource name
+  parameters?: any;
+  response?: any;
+  userIntent?: string;
+
+  // Error tracking
+  isError?: boolean;
+  error?: object;
+
+  // Legacy fields for MCPCat API compatibility
+  actorId?: string; // Maps to identifyActorGivenId in some contexts
+  eventId?: string; // Custom event ID
+  identifyData?: object; // Legacy name for identifyActorData
+}
+
+export interface UnredactedEvent extends Partial<Event> {
   redactionFn?: RedactFunction; // Optional redaction function for sensitive data
 }
 


### PR DESCRIPTION
## Summary

Adds support for telemetry exporters to enable sending MCP analytics to existing observability infrastructure. Users can now export events to OpenTelemetry collectors, Datadog, Sentry, or console output.

## Key Features

- **Telemetry-only mode**: Pass `null` as projectId to use only telemetry exporters without MCPCat account
- **Dual mode**: Send events to both MCPCat and telemetry exporters simultaneously  
- **Multiple exporters**: Configure multiple exporters to send data to different systems

## Supported Exporters

- **OTLP**: OpenTelemetry Protocol for standard observability tools
- **Datadog**: Logs and metrics with proper tagging
- **Sentry**: Performance monitoring and error tracking
- 
## Example

```typescript
mcpcat.track(mcpServer, null, {
  exporters: {
    otlp: {
      type: "otlp",
      endpoint: "http://localhost:4318/v1/traces"
    }
  }
});
```