### PR TITLE
feat: add customizable context parameter description for tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcpcat",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Analytics tool for MCP (Model Context Protocol) servers - tracks tool usage patterns and provides insights",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { setTelemetryManager } from "./modules/eventQueue.js";
  * @param options.enableReportMissing - Adds a "get_more_tools" tool that allows LLMs to automatically report missing functionality.
  * @param options.enableTracing - Enables tracking of tool calls and usage patterns.
  * @param options.enableToolCallContext - Injects a "context" parameter to existing tools to capture user intent.
+ * @param options.customContextDescription - Custom description for the injected context parameter. Only applies when enableToolCallContext is true. Use this to provide domain-specific guidance to LLMs about what context they should provide.
  * @param options.identify - Async function to identify users and attach custom data to their sessions.
  * @param options.redactSensitiveInformation - Function to redact sensitive data before sending to MCPCat.
  * @param options.exporters - Configure telemetry exporters to send events to external systems. Available exporters:
@@ -71,6 +72,15 @@ import { setTelemetryManager } from "./modules/eventQueue.js";
  *       userData: { plan: user.plan, company: user.company }
  *     };
  *   }
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // With custom context description
+ * mcpcat.track(mcpServer, "proj_abc123xyz", {
+ *   enableToolCallContext: true,
+ *   customContextDescription: "Explain why you're calling this tool and what business objective it helps achieve"
  * });
  * ```
  *
@@ -153,6 +163,7 @@ function track(
         enableReportMissing: options.enableReportMissing ?? true,
         enableTracing: options.enableTracing ?? true,
         enableToolCallContext: options.enableToolCallContext ?? true,
+        customContextDescription: options.customContextDescription,
         identify: options.identify,
         redactSensitiveInformation: options.redactSensitiveInformation,
       },

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -1,2 +1,4 @@
 // MCPCat Settings
 export const INACTIVITY_TIMEOUT_IN_MINUTES = 30;
+export const DEFAULT_CONTEXT_PARAMETER_DESCRIPTION =
+  "Describe why you are calling this tool and how it fits into your overall task";

--- a/src/modules/context-parameters.ts
+++ b/src/modules/context-parameters.ts
@@ -1,5 +1,6 @@
 import { RegisteredTool } from "../types";
 import { z } from "zod";
+import { DEFAULT_CONTEXT_PARAMETER_DESCRIPTION } from "./constants";
 
 // Detect if something is a Zod schema (has _def and parse methods)
 function isZodSchema(schema: any): boolean {
@@ -23,6 +24,7 @@ function isShorthandZodSyntax(schema: any): boolean {
 
 export function addContextParameterToTool(
   tool: RegisteredTool,
+  customContextDescription?: string,
 ): RegisteredTool {
   // Create a shallow copy of the tool to avoid modifying the original
   const modifiedTool = { ...tool };
@@ -55,7 +57,7 @@ export function addContextParameterToTool(
       context: z
         .string()
         .describe(
-          "Describe why you are calling this tool and how it fits into your overall task",
+          customContextDescription || DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
         ),
     });
 
@@ -86,7 +88,7 @@ export function addContextParameterToTool(
     const contextField = z
       .string()
       .describe(
-        "Describe why you are calling this tool and how it fits into your overall task",
+        customContextDescription || DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
       );
 
     // Create new z.object with context and all original fields
@@ -114,7 +116,7 @@ export function addContextParameterToTool(
     modifiedTool.inputSchema.properties.context = {
       type: "string",
       description:
-        "Describe why you are calling this tool and how it fits into your overall task",
+        customContextDescription || DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
     };
 
     // Add context to required array if it exists
@@ -133,12 +135,13 @@ export function addContextParameterToTool(
 
 export function addContextParameterToTools(
   tools: RegisteredTool[],
+  customContextDescription?: string,
 ): RegisteredTool[] {
   return tools.map((tool) => {
     // Skip get_more_tools - it has its own special context parameter
     if ((tool as any).name === "get_more_tools") {
       return tool;
     }
-    return addContextParameterToTool(tool);
+    return addContextParameterToTool(tool, customContextDescription);
   });
 }

--- a/src/modules/internal.ts
+++ b/src/modules/internal.ts
@@ -1,4 +1,4 @@
-import { MCPCatData, MCPServerLike } from "../types.js";
+import { MCPCatData, MCPServerLike, UserIdentity } from "../types.js";
 
 // Internal tracking storage
 const _serverTracking = new WeakMap<MCPServerLike, MCPCatData>();
@@ -14,4 +14,50 @@ export function setServerTrackingData(
   data: MCPCatData,
 ): void {
   _serverTracking.set(server, data);
+}
+
+/**
+ * Deep comparison of two UserIdentity objects
+ */
+export function areIdentitiesEqual(a: UserIdentity, b: UserIdentity): boolean {
+  if (a.userId !== b.userId) return false;
+  if (a.userName !== b.userName) return false;
+
+  // Deep compare userData objects
+  const aData = a.userData || {};
+  const bData = b.userData || {};
+
+  const aKeys = Object.keys(aData);
+  const bKeys = Object.keys(bData);
+
+  if (aKeys.length !== bKeys.length) return false;
+
+  for (const key of aKeys) {
+    if (!(key in bData)) return false;
+    if (JSON.stringify(aData[key]) !== JSON.stringify(bData[key])) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Merges two UserIdentity objects, overwriting userId and userName,
+ * but merging userData fields
+ */
+export function mergeIdentities(
+  previous: UserIdentity | undefined,
+  next: UserIdentity,
+): UserIdentity {
+  if (!previous) {
+    return next;
+  }
+
+  return {
+    userId: next.userId,
+    userName: next.userName,
+    userData: {
+      ...(previous.userData || {}),
+      ...(next.userData || {}),
+    },
+  };
 }

--- a/src/modules/tools.ts
+++ b/src/modules/tools.ts
@@ -97,7 +97,10 @@ export function setupMCPCatTools(server: MCPServerLike): void {
 
       // Add context parameter to all existing tools if enableToolCallContext is true
       if (data.options.enableToolCallContext) {
-        tools = addContextParameterToTools(tools);
+        tools = addContextParameterToTools(
+          tools,
+          data.options.customContextDescription,
+        );
       }
 
       // Add report_missing tool if enabled

--- a/src/tests/context-parameters.test.ts
+++ b/src/tests/context-parameters.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types";
 import { EventCapture } from "./test-utils";
 import { PublishEventRequestEventTypeEnum } from "mcpcat-api";
+import { DEFAULT_CONTEXT_PARAMETER_DESCRIPTION } from "../modules/constants";
 
 describe("Context Parameters", () => {
   let server: any;
@@ -348,7 +349,39 @@ describe("Context Parameters", () => {
         expect(tool.inputSchema.properties.context).toBeDefined();
         expect(tool.inputSchema.properties.context.type).toBe("string");
         expect(tool.inputSchema.properties.context.description).toBe(
-          "Describe why you are calling this tool and how it fits into your overall task",
+          DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
+        );
+      });
+    });
+
+    it("should use default context description when no custom description is provided", async () => {
+      // Enable tracking WITHOUT customContextDescription
+      track(server, "test-project", {
+        enableToolCallContext: true,
+      });
+
+      // Get the tools list
+      const toolsResponse = await client.request(
+        {
+          method: "tools/list",
+          params: {},
+        },
+        ListToolsResultSchema,
+      );
+
+      // Find all original tools
+      const originalTools = ["add_todo", "list_todos", "complete_todo"];
+      const toolsToCheck = toolsResponse.tools.filter((tool: any) =>
+        originalTools.includes(tool.name),
+      );
+
+      expect(toolsToCheck.length).toBe(3);
+
+      // Verify all tools use the default description
+      toolsToCheck.forEach((tool: any) => {
+        expect(tool.inputSchema.properties.context).toBeDefined();
+        expect(tool.inputSchema.properties.context.description).toBe(
+          DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
         );
       });
     });

--- a/src/tests/custom-context-description.test.ts
+++ b/src/tests/custom-context-description.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  setupTestServerAndClient,
+  resetTodos,
+} from "./test-utils/client-server-factory";
+import { track } from "../index";
+import {
+  CallToolResultSchema,
+  ListToolsResultSchema,
+} from "@modelcontextprotocol/sdk/types";
+import { EventCapture } from "./test-utils";
+import { PublishEventRequestEventTypeEnum } from "mcpcat-api";
+import { DEFAULT_CONTEXT_PARAMETER_DESCRIPTION } from "../modules/constants";
+
+describe("Custom Context Description", () => {
+  let server: any;
+  let client: any;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    resetTodos();
+    const setup = await setupTestServerAndClient();
+    server = setup.server;
+    client = setup.client;
+    cleanup = setup.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("should use custom description instead of default for JSON Schema tools", async () => {
+    const customDescription = "Explain your reasoning for this action";
+
+    // Enable tracking with custom context description
+    track(server, "test-project", {
+      enableToolCallContext: true,
+      customContextDescription: customDescription,
+    });
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: "tools/list",
+        params: {},
+      },
+      ListToolsResultSchema,
+    );
+
+    // Find the add_todo tool (uses shorthand Zod syntax)
+    const addTodoTool = toolsResponse.tools.find(
+      (tool: any) => tool.name === "add_todo",
+    );
+
+    expect(addTodoTool).toBeDefined();
+    expect(addTodoTool.inputSchema.properties.context).toBeDefined();
+    expect(addTodoTool.inputSchema.properties.context.description).toBe(
+      customDescription,
+    );
+    expect(addTodoTool.inputSchema.properties.context.description).not.toBe(
+      DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
+    );
+  });
+
+  it("should use custom description for Zod object schemas", async () => {
+    const customDescription = "Provide context about why you're doing this";
+
+    // Enable tracking with custom context description
+    track(server, "test-project", {
+      enableToolCallContext: true,
+      customContextDescription: customDescription,
+    });
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: "tools/list",
+        params: {},
+      },
+      ListToolsResultSchema,
+    );
+
+    // Find the complete_todo tool (uses registerTool with Zod schema)
+    const completeTodoTool = toolsResponse.tools.find(
+      (tool: any) => tool.name === "complete_todo",
+    );
+
+    expect(completeTodoTool).toBeDefined();
+    expect(completeTodoTool.inputSchema.properties.context).toBeDefined();
+    expect(completeTodoTool.inputSchema.properties.context.description).toBe(
+      customDescription,
+    );
+  });
+
+  it("should apply custom description to all tools when listing", async () => {
+    const customDescription = "Why are you calling this tool?";
+
+    // Enable tracking with custom context description
+    track(server, "test-project", {
+      enableToolCallContext: true,
+      customContextDescription: customDescription,
+    });
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: "tools/list",
+        params: {},
+      },
+      ListToolsResultSchema,
+    );
+
+    // Check all original tools (exclude MCPCat-added tools)
+    const originalTools = ["add_todo", "list_todos", "complete_todo"];
+    const toolsToCheck = toolsResponse.tools.filter((tool: any) =>
+      originalTools.includes(tool.name),
+    );
+
+    expect(toolsToCheck.length).toBe(3);
+
+    toolsToCheck.forEach((tool: any) => {
+      expect(tool.inputSchema.properties.context).toBeDefined();
+      expect(tool.inputSchema.properties.context.description).toBe(
+        customDescription,
+      );
+    });
+  });
+
+  it("should capture tool calls with custom description configured", async () => {
+    const customDescription = "Tell me what you're trying to accomplish";
+    const eventCapture = new EventCapture();
+    await eventCapture.start();
+
+    // Enable tracking with custom context description
+    track(server, "test-project", {
+      enableToolCallContext: true,
+      enableTracing: true,
+      customContextDescription: customDescription,
+    });
+
+    // Call a tool with context
+    const contextString = "I need to add a task to my list";
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "add_todo",
+          arguments: {
+            text: "Test todo item",
+            context: contextString,
+          },
+        },
+      },
+      CallToolResultSchema,
+    );
+
+    expect(result.content[0].text).toContain("Added todo");
+
+    // Wait for events to be processed
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Verify that the event was captured with the user intent
+    const events = eventCapture.getEvents();
+    const toolCallEvent = events.find(
+      (e) =>
+        e.eventType === PublishEventRequestEventTypeEnum.mcpToolsCall &&
+        e.resourceName === "add_todo",
+    );
+
+    expect(toolCallEvent).toBeDefined();
+    expect(toolCallEvent?.userIntent).toBe(contextString);
+
+    await eventCapture.stop();
+  });
+
+  it("should use default description when customContextDescription is not provided", async () => {
+    // Enable tracking WITHOUT custom context description
+    track(server, "test-project", {
+      enableToolCallContext: true,
+    });
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: "tools/list",
+        params: {},
+      },
+      ListToolsResultSchema,
+    );
+
+    // Find the add_todo tool
+    const addTodoTool = toolsResponse.tools.find(
+      (tool: any) => tool.name === "add_todo",
+    );
+
+    expect(addTodoTool).toBeDefined();
+    expect(addTodoTool.inputSchema.properties.context).toBeDefined();
+    expect(addTodoTool.inputSchema.properties.context.description).toBe(
+      DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
+    );
+  });
+
+  it("should work end-to-end with custom description and multiple tool calls", async () => {
+    const customDescription = "Explain your intent for this operation";
+    const eventCapture = new EventCapture();
+    await eventCapture.start();
+
+    // Enable tracking with custom context description
+    track(server, "test-project", {
+      enableToolCallContext: true,
+      enableTracing: true,
+      customContextDescription: customDescription,
+    });
+
+    // Verify tools list has custom description
+    const toolsResponse = await client.request(
+      {
+        method: "tools/list",
+        params: {},
+      },
+      ListToolsResultSchema,
+    );
+
+    const addTodoTool = toolsResponse.tools.find(
+      (tool: any) => tool.name === "add_todo",
+    );
+    expect(addTodoTool.inputSchema.properties.context.description).toBe(
+      customDescription,
+    );
+
+    // Call add_todo
+    await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "add_todo",
+          arguments: {
+            text: "First task",
+            context: "Setting up my first task",
+          },
+        },
+      },
+      CallToolResultSchema,
+    );
+
+    // Call complete_todo
+    await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "complete_todo",
+          arguments: {
+            id: "1",
+            context: "Finishing the first task",
+          },
+        },
+      },
+      CallToolResultSchema,
+    );
+
+    // Call list_todos
+    await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "list_todos",
+          arguments: {
+            context: "Checking my progress",
+          },
+        },
+      },
+      CallToolResultSchema,
+    );
+
+    // Wait for events to be processed
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Verify all events were captured with user intent
+    const events = eventCapture.getEvents();
+    const toolCallEvents = events.filter(
+      (e) => e.eventType === PublishEventRequestEventTypeEnum.mcpToolsCall,
+    );
+
+    expect(toolCallEvents.length).toBeGreaterThanOrEqual(3);
+
+    const addEvent = toolCallEvents.find((e) => e.resourceName === "add_todo");
+    const completeEvent = toolCallEvents.find(
+      (e) => e.resourceName === "complete_todo",
+    );
+    const listEvent = toolCallEvents.find(
+      (e) => e.resourceName === "list_todos",
+    );
+
+    expect(addEvent?.userIntent).toBe("Setting up my first task");
+    expect(completeEvent?.userIntent).toBe("Finishing the first task");
+    expect(listEvent?.userIntent).toBe("Checking my progress");
+
+    await eventCapture.stop();
+  });
+
+  it("should use custom description even with long descriptions", async () => {
+    const customDescription =
+      "Please provide a comprehensive explanation of your reasoning, including the broader context of this action within your workflow, the expected outcomes, and how this contributes to your overall objectives. Be as detailed as possible.";
+
+    // Enable tracking with long custom context description
+    track(server, "test-project", {
+      enableToolCallContext: true,
+      customContextDescription: customDescription,
+    });
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: "tools/list",
+        params: {},
+      },
+      ListToolsResultSchema,
+    );
+
+    const addTodoTool = toolsResponse.tools.find(
+      (tool: any) => tool.name === "add_todo",
+    );
+
+    expect(addTodoTool.inputSchema.properties.context.description).toBe(
+      customDescription,
+    );
+  });
+
+  it("should use custom description with special characters", async () => {
+    const customDescription = 'Why? (explain in detail) - "Be specific!"';
+
+    // Enable tracking with special characters in description
+    track(server, "test-project", {
+      enableToolCallContext: true,
+      customContextDescription: customDescription,
+    });
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: "tools/list",
+        params: {},
+      },
+      ListToolsResultSchema,
+    );
+
+    const addTodoTool = toolsResponse.tools.find(
+      (tool: any) => tool.name === "add_todo",
+    );
+
+    expect(addTodoTool.inputSchema.properties.context.description).toBe(
+      customDescription,
+    );
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface MCPCatOptions {
   enableReportMissing?: boolean;
   enableTracing?: boolean;
   enableToolCallContext?: boolean;
+  customContextDescription?: string;
   identify?: (
     request: any,
     extra?: CompatibleRequestHandlerExtra,


### PR DESCRIPTION
  Allow users to customize the description text for the context parameter
  that's added to MCP tools. Defaults to the standard description but can
  be overridden via customContextDescription in MCPCatOptions.