### PR TITLE
refactor: wrap setRequestHandler for high-level servers

### DIFF
--- a/src/modules/exceptions.ts
+++ b/src/modules/exceptions.ts
@@ -31,14 +31,14 @@ export function captureException(
   if (!(error instanceof Error)) {
     return {
       message: stringifyNonError(error),
-      type: "UnknownErrorType",
+      type: undefined,
       platform: "javascript",
     };
   }
 
   const errorData: ErrorData = {
     message: error.message || "",
-    type: error.name || error.constructor?.name || "Error",
+    type: error.name || error.constructor?.name || undefined,
     platform: "javascript",
   };
 

--- a/src/modules/exceptions.ts
+++ b/src/modules/exceptions.ts
@@ -15,9 +15,18 @@ const MAX_STACK_FRAMES = 50;
  * detects whether each frame is user code (in_app: true) or library code (in_app: false).
  *
  * @param error - The error to capture (can be Error, string, object, or any value)
+ * @param contextStack - Optional Error object to use for stack context (for validation errors)
  * @returns ErrorData object with structured error information
  */
-export function captureException(error: unknown): ErrorData {
+export function captureException(
+  error: unknown,
+  contextStack?: Error,
+): ErrorData {
+  // Handle CallToolResult objects (SDK 1.21.0+ converts errors to these)
+  if (isCallToolResult(error)) {
+    return captureCallToolResultError(error, contextStack);
+  }
+
   // Handle non-Error objects
   if (!(error instanceof Error)) {
     return {
@@ -706,6 +715,57 @@ function unwrapErrorCauses(error: Error): ChainedErrorData[] {
   }
 
   return chainedErrors;
+}
+
+/**
+ * Detects if a value is a CallToolResult object (SDK 1.21.0+ error format).
+ *
+ * SDK 1.21.0+ converts errors to CallToolResult format:
+ * { content: [{ type: "text", text: "error message" }], isError: true }
+ *
+ * @param value - Value to check
+ * @returns True if value is a CallToolResult object
+ */
+function isCallToolResult(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "isError" in value &&
+    "content" in value &&
+    Array.isArray((value as any).content)
+  );
+}
+
+/**
+ * Extracts error information from CallToolResult objects.
+ *
+ * SDK 1.21.0+ converts errors to CallToolResult, losing original stack traces.
+ * This extracts the error message from the content array.
+ *
+ * @param result - CallToolResult object with error
+ * @param _contextStack - Optional Error object for stack context (unused, kept for compatibility)
+ * @returns ErrorData with extracted message (no stack trace)
+ */
+function captureCallToolResultError(
+  result: any,
+  _contextStack?: Error,
+): ErrorData {
+  // Extract message from content array
+  const message =
+    result.content
+      ?.filter((c: any) => c.type === "text")
+      .map((c: any) => c.text)
+      .join(" ")
+      .trim() || "Unknown error";
+
+  const errorData: ErrorData = {
+    message,
+    type: "NonError", // Can't determine actual type from CallToolResult
+    platform: "javascript",
+    // No stack or frames - SDK stripped the original error information
+  };
+
+  return errorData;
 }
 
 /**

--- a/src/modules/exceptions.ts
+++ b/src/modules/exceptions.ts
@@ -31,7 +31,7 @@ export function captureException(
   if (!(error instanceof Error)) {
     return {
       message: stringifyNonError(error),
-      type: "NonError",
+      type: "UnknownErrorType",
       platform: "javascript",
     };
   }
@@ -686,7 +686,7 @@ function unwrapErrorCauses(error: Error): ChainedErrorData[] {
     if (!(currentError instanceof Error)) {
       chainedErrors.push({
         message: stringifyNonError(currentError),
-        type: "NonError",
+        type: "UnknownErrorType",
       });
       break;
     }
@@ -760,7 +760,7 @@ function captureCallToolResultError(
 
   const errorData: ErrorData = {
     message,
-    type: "NonError", // Can't determine actual type from CallToolResult
+    type: "UnknownErrorType", // Can't determine actual type from CallToolResult
     platform: "javascript",
     // No stack or frames - SDK stripped the original error information
   };

--- a/src/tests/error-capture.test.ts
+++ b/src/tests/error-capture.test.ts
@@ -237,7 +237,7 @@ describe("Error Capture Integration Tests", () => {
       const errorEvent = events.find((e) => e.isError);
 
       expect(errorEvent).toBeDefined();
-      expect(errorEvent!.error!.type).toBe("NonError");
+      expect(errorEvent!.error!.type).toBe("UnknownErrorType");
       expect(errorEvent!.error!.message).toContain("This is a string error");
       // Non-Error throws don't have stack traces
       // (SDK converts them, we can't capture at callback level)
@@ -486,8 +486,8 @@ describe("Error Capture Integration Tests", () => {
       expect(errorEvent!.error!.message).toContain("Invalid");
 
       // Type can vary by SDK version
-      // SDK 1.11.5: "McpError", SDK 1.21.0+: "NonError"
-      expect(["McpError", "NonError", "Error"]).toContain(
+      // SDK 1.11.5: "McpError", SDK 1.21.0+: "UnknownErrorType"
+      expect(["McpError", "UnknownErrorType", "Error"]).toContain(
         errorEvent!.error!.type,
       );
 
@@ -550,7 +550,7 @@ describe("Error Capture Integration Tests", () => {
       expect(errorEvent!.error!.message).toContain("not found");
 
       // Type can vary by SDK version
-      expect(["McpError", "NonError", "Error"]).toContain(
+      expect(["McpError", "UnknownErrorType", "Error"]).toContain(
         errorEvent!.error!.type,
       );
 
@@ -606,7 +606,7 @@ describe("Error Capture Integration Tests", () => {
       expect(errorEvent!.error!.message).toContain("Invalid");
 
       // Type can vary by SDK version
-      expect(["McpError", "NonError", "Error"]).toContain(
+      expect(["McpError", "UnknownErrorType", "Error"]).toContain(
         errorEvent!.error!.type,
       );
 

--- a/src/tests/exceptions.test.ts
+++ b/src/tests/exceptions.test.ts
@@ -272,7 +272,7 @@ describe("captureException", () => {
       expect(result.chained_errors).toBeDefined();
       expect(result.chained_errors!.length).toBe(1);
       expect(result.chained_errors![0].message).toBe("string cause");
-      expect(result.chained_errors![0].type).toBe("NonError");
+      expect(result.chained_errors![0].type).toBe("UnknownErrorType");
     });
 
     it("should detect circular cause references", () => {
@@ -306,7 +306,7 @@ describe("captureException", () => {
       const result = captureException("string error");
 
       expect(result.message).toBe("string error");
-      expect(result.type).toBe("NonError");
+      expect(result.type).toBe("UnknownErrorType");
       expect(result.stack).toBeUndefined();
       expect(result.frames).toBeUndefined();
     });
@@ -315,35 +315,35 @@ describe("captureException", () => {
       const result = captureException(42);
 
       expect(result.message).toBe("42");
-      expect(result.type).toBe("NonError");
+      expect(result.type).toBe("UnknownErrorType");
     });
 
     it("should handle boolean errors", () => {
       const result = captureException(false);
 
       expect(result.message).toBe("false");
-      expect(result.type).toBe("NonError");
+      expect(result.type).toBe("UnknownErrorType");
     });
 
     it("should handle null", () => {
       const result = captureException(null);
 
       expect(result.message).toBe("null");
-      expect(result.type).toBe("NonError");
+      expect(result.type).toBe("UnknownErrorType");
     });
 
     it("should handle undefined", () => {
       const result = captureException(undefined);
 
       expect(result.message).toBe("undefined");
-      expect(result.type).toBe("NonError");
+      expect(result.type).toBe("UnknownErrorType");
     });
 
     it("should handle object errors", () => {
       const result = captureException({ code: 404, message: "Not found" });
 
       expect(result.message).toBe('{"code":404,"message":"Not found"}');
-      expect(result.type).toBe("NonError");
+      expect(result.type).toBe("UnknownErrorType");
     });
 
     it("should handle objects with circular references", () => {
@@ -352,7 +352,7 @@ describe("captureException", () => {
 
       const result = captureException(obj);
 
-      expect(result.type).toBe("NonError");
+      expect(result.type).toBe("UnknownErrorType");
       // Should not throw, should return some string representation
       expect(typeof result.message).toBe("string");
     });

--- a/src/tests/exceptions.test.ts
+++ b/src/tests/exceptions.test.ts
@@ -306,7 +306,7 @@ describe("captureException", () => {
       const result = captureException("string error");
 
       expect(result.message).toBe("string error");
-      expect(result.type).toBe("UnknownErrorType");
+      expect(result.type).toBeUndefined();
       expect(result.stack).toBeUndefined();
       expect(result.frames).toBeUndefined();
     });
@@ -315,35 +315,35 @@ describe("captureException", () => {
       const result = captureException(42);
 
       expect(result.message).toBe("42");
-      expect(result.type).toBe("UnknownErrorType");
+      expect(result.type).toBeUndefined();
     });
 
     it("should handle boolean errors", () => {
       const result = captureException(false);
 
       expect(result.message).toBe("false");
-      expect(result.type).toBe("UnknownErrorType");
+      expect(result.type).toBeUndefined();
     });
 
     it("should handle null", () => {
       const result = captureException(null);
 
       expect(result.message).toBe("null");
-      expect(result.type).toBe("UnknownErrorType");
+      expect(result.type).toBeUndefined();
     });
 
     it("should handle undefined", () => {
       const result = captureException(undefined);
 
       expect(result.message).toBe("undefined");
-      expect(result.type).toBe("UnknownErrorType");
+      expect(result.type).toBeUndefined();
     });
 
     it("should handle object errors", () => {
       const result = captureException({ code: 404, message: "Not found" });
 
       expect(result.message).toBe('{"code":404,"message":"Not found"}');
-      expect(result.type).toBe("UnknownErrorType");
+      expect(result.type).toBeUndefined();
     });
 
     it("should handle objects with circular references", () => {
@@ -352,7 +352,7 @@ describe("captureException", () => {
 
       const result = captureException(obj);
 
-      expect(result.type).toBe("UnknownErrorType");
+      expect(result.type).toBeUndefined();
       // Should not throw, should return some string representation
       expect(typeof result.message).toBe("string");
     });

--- a/src/tests/tracing-initialization.test.ts
+++ b/src/tests/tracing-initialization.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  setupTestServerAndClient,
+  resetTodos,
+} from "./test-utils/client-server-factory.js";
+import { track } from "../index.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { EventCapture } from "./test-utils.js";
+
+describe("Tracing Initialization Tests", () => {
+  let eventCapture: EventCapture;
+
+  beforeEach(async () => {
+    resetTodos();
+    eventCapture = new EventCapture();
+    await eventCapture.start();
+  });
+
+  afterEach(async () => {
+    await eventCapture.stop();
+  });
+
+  it("should not create duplicate events when track() is called multiple times", async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient();
+
+    try {
+      // Call track() multiple times on the same server instance
+      await track(server, {
+        projectId: "test-project",
+        enableTracing: true,
+      });
+
+      await track(server, {
+        projectId: "test-project",
+        enableTracing: true,
+      });
+
+      await track(server, {
+        projectId: "test-project",
+        enableTracing: true,
+      });
+
+      // First add a todo so we can complete it
+      await client.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "add_todo",
+            arguments: {
+              text: "Test todo for double-wrapping",
+              context: "Setup for double-wrapping test",
+            },
+          },
+        },
+        CallToolResultSchema,
+      );
+
+      // Wait for event to be published
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Clear events from setup
+      eventCapture.clear();
+
+      // Execute the actual test tool call
+      const result = await client.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "complete_todo",
+            arguments: {
+              id: "1",
+              context: "Testing double-wrapping protection",
+            },
+          },
+        },
+        CallToolResultSchema,
+      );
+
+      // Wait for any events to be published
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify the tool call succeeded (successful calls have undefined isError)
+      expect(result).toBeDefined();
+      expect(result.isError).not.toBe(true);
+
+      // Get all events published
+      const events = eventCapture.getEvents();
+
+      // Should have exactly 1 event, not 3 (one per track() call)
+      expect(events.length).toBe(1);
+      expect(events[0].resourceName).toBe("complete_todo");
+      expect(events[0].isError).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("should publish events for successful tool calls with handler-level architecture", async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient();
+
+    try {
+      // Initialize tracing with track()
+      await track(server, {
+        projectId: "test-project",
+        enableTracing: true,
+      });
+
+      // Execute a successful tool call
+      const result = await client.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "add_todo",
+            arguments: {
+              text: "Test successful handler wrapping",
+              context: "Testing handler-level event publishing",
+            },
+          },
+        },
+        CallToolResultSchema,
+      );
+
+      // Wait for event to be published
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify tool call succeeded (successful calls have undefined isError)
+      expect(result).toBeDefined();
+      expect(result.isError).not.toBe(true);
+
+      // Get events
+      const events = eventCapture.getEvents();
+
+      // Should have exactly 1 event for the successful call
+      expect(events.length).toBe(1);
+      expect(events[0].resourceName).toBe("add_todo");
+      expect(events[0].isError).toBeUndefined();
+      expect(events[0].userIntent).toBe(
+        "Testing handler-level event publishing",
+      );
+
+      // Verify event has the expected structure
+      expect(events[0]).toHaveProperty("eventType");
+      expect(events[0]).toHaveProperty("timestamp");
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

### Modified
- Refactored tracing architecture from per-tool callback wrapping to handler-level wrapping in `tracingV2.ts`
- Added `setupToolsCallHandlerWrapping()` to intercept `setRequestHandler()` calls for tools/call handler
- Added `createToolsCallWrapper()` to centralize tracing logic at the protocol handler level
- Simplified `addTracingToToolCallback()` to only remove context from args instead of handling full tracing

## Test Plan
- [x] All existing tests pass
- [x] Type checks pass
- [x] New tests added for handler-level architecture
- [x] Tests verify no duplicate events when track() called multiple times
- [x] Tests verify context parameter is properly removed before callback execution