### PR TITLE
fix: return undefined error type for non-Error values

### DIFF
--- a/src/modules/exceptions.ts
+++ b/src/modules/exceptions.ts
@@ -686,7 +686,7 @@ function unwrapErrorCauses(error: Error): ChainedErrorData[] {
     if (!(currentError instanceof Error)) {
       chainedErrors.push({
         message: stringifyNonError(currentError),
-        type: "UnknownErrorType",
+        type: undefined,
       });
       break;
     }
@@ -760,7 +760,7 @@ function captureCallToolResultError(
 
   const errorData: ErrorData = {
     message,
-    type: "UnknownErrorType", // Can't determine actual type from CallToolResult
+    type: undefined, // Can't determine actual type from CallToolResult
     platform: "javascript",
     // No stack or frames - SDK stripped the original error information
   };

--- a/src/tests/error-capture.test.ts
+++ b/src/tests/error-capture.test.ts
@@ -237,7 +237,7 @@ describe("Error Capture Integration Tests", () => {
       const errorEvent = events.find((e) => e.isError);
 
       expect(errorEvent).toBeDefined();
-      expect(errorEvent!.error!.type).toBe("UnknownErrorType");
+      expect(errorEvent!.error!.type).toBeUndefined();
       expect(errorEvent!.error!.message).toContain("This is a string error");
       // Non-Error throws don't have stack traces
       // (SDK converts them, we can't capture at callback level)
@@ -486,8 +486,8 @@ describe("Error Capture Integration Tests", () => {
       expect(errorEvent!.error!.message).toContain("Invalid");
 
       // Type can vary by SDK version
-      // SDK 1.11.5: "McpError", SDK 1.21.0+: "UnknownErrorType"
-      expect(["McpError", "UnknownErrorType", "Error"]).toContain(
+      // SDK 1.11.5: "McpError" (actual Error), SDK 1.21.0+: undefined (CallToolResult)
+      expect(["McpError", "Error", undefined]).toContain(
         errorEvent!.error!.type,
       );
 
@@ -550,7 +550,8 @@ describe("Error Capture Integration Tests", () => {
       expect(errorEvent!.error!.message).toContain("not found");
 
       // Type can vary by SDK version
-      expect(["McpError", "UnknownErrorType", "Error"]).toContain(
+      // SDK 1.11.5: "McpError" (actual Error), SDK 1.21.0+: undefined (CallToolResult)
+      expect(["McpError", "Error", undefined]).toContain(
         errorEvent!.error!.type,
       );
 
@@ -606,7 +607,8 @@ describe("Error Capture Integration Tests", () => {
       expect(errorEvent!.error!.message).toContain("Invalid");
 
       // Type can vary by SDK version
-      expect(["McpError", "UnknownErrorType", "Error"]).toContain(
+      // SDK 1.11.5: "McpError" (actual Error), SDK 1.21.0+: undefined (CallToolResult)
+      expect(["McpError", "Error", undefined]).toContain(
         errorEvent!.error!.type,
       );
 

--- a/src/tests/exceptions.test.ts
+++ b/src/tests/exceptions.test.ts
@@ -272,7 +272,7 @@ describe("captureException", () => {
       expect(result.chained_errors).toBeDefined();
       expect(result.chained_errors!.length).toBe(1);
       expect(result.chained_errors![0].message).toBe("string cause");
-      expect(result.chained_errors![0].type).toBe("UnknownErrorType");
+      expect(result.chained_errors![0].type).toBeUndefined();
     });
 
     it("should detect circular cause references", () => {


### PR DESCRIPTION
## Summary

### Modified
- `captureException` now returns `undefined` type for non-Error objects (instead of `"UnknownErrorType"`)
- `unwrapErrorCauses` returns `undefined` type for non-Error causes in error chains
- `captureCallToolResultError` returns `undefined` type when SDK converts errors to CallToolResult format

### Fixed
- Updated test assertions to expect `undefined` instead of `"UnknownErrorType"` for non-Error values
- Updated SDK version-dependent tests to include `undefined` in valid type values

## Test Plan
- [x] All 253 tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes