### PR TITLE
fix: stop publishing error events for identify function failures

### DIFF
--- a/src/modules/internal.ts
+++ b/src/modules/internal.ts
@@ -8,7 +8,6 @@ import {
 import { PublishEventRequestEventTypeEnum } from "mcpcat-api";
 import { publishEvent } from "./eventQueue.js";
 import { writeToLog } from "./logging.js";
-import { captureException } from "./exceptions.js";
 
 /**
  * Simple LRU cache for session identities.
@@ -196,14 +195,7 @@ export async function handleIdentify(
     }
   } catch (error) {
     writeToLog(
-      `Warning: Supplied identify function threw an error while identifying session ${sessionId} - ${error}`,
+      `Error: User supplied identify function threw an error while identifying session ${sessionId} - ${error}`,
     );
-    identifyEvent.duration =
-      (identifyEvent.timestamp &&
-        new Date().getTime() - identifyEvent.timestamp.getTime()) ||
-      undefined;
-    identifyEvent.isError = true;
-    identifyEvent.error = captureException(error);
-    publishEvent(server, identifyEvent);
   }
 }

--- a/src/tests/identify.test.ts
+++ b/src/tests/identify.test.ts
@@ -685,16 +685,13 @@ describe("Identify Feature", () => {
       // Wait for events
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      // Verify identify event was published with error
+      // Verify NO identify event was published (errors in identify function should not publish events)
       const events = eventCapture.getEvents();
       const identifyEvent = events.find(
         (e) => e.eventType === PublishEventRequestEventTypeEnum.mcpcatIdentify,
       );
 
-      expect(identifyEvent).toBeDefined();
-      expect(identifyEvent?.isError).toBe(true);
-      expect(identifyEvent?.error?.message).toContain(errorMessage);
-      expect(identifyEvent?.duration).toBeDefined();
+      expect(identifyEvent).toBeUndefined();
 
       // Verify no user identity was stored
       const data = getServerTrackingData(server.server);

--- a/src/tests/report-missing.test.ts
+++ b/src/tests/report-missing.test.ts
@@ -261,7 +261,7 @@ describe("Report Missing Tool", () => {
       await eventCapture.start();
 
       // Enable tracking
-      track(server, "proj_0ujtsYcgvSTl8PAuAdqWYSMnLOv");
+      track(server, "proj_abc123xyz");
 
       const description = "Need file system watcher tool";
       const context = "User wants to monitor file changes in real-time";


### PR DESCRIPTION
## Summary
- When the user-supplied identify function throws an error, log the error instead of publishing an identify error event
- This prevents noisy/misleading analytics data from user code issues
- Updated log level from "Warning" to "Error" for clarity

## Test plan
- [x] Updated existing identify error tests to verify no event is published
- [x] Updated error-capture integration test to verify behavior
- [x] All existing tests pass