### PR TITLE
refactor: use captureException for error handling in list tools

### DIFF
--- a/src/modules/tools.ts
+++ b/src/modules/tools.ts
@@ -9,7 +9,7 @@ import { addContextParameterToTools } from "./context-parameters.js";
 import { publishEvent } from "./eventQueue.js";
 import { getServerSessionId } from "./session.js";
 import { PublishEventRequestEventTypeEnum } from "mcpcat-api";
-import { getMCPCompatibleErrorMessage } from "./compatibility.js";
+import { captureException } from "./exceptions.js";
 
 export const GET_MORE_TOOLS_NAME = "get_more_tools" as const;
 
@@ -85,7 +85,7 @@ export function setupMCPCatTools(server: MCPServerLike): void {
         writeToLog(
           `Warning: Original list tools handler failed, this suggests an error MCPCat did not cause - ${error}`,
         );
-        event.error = { message: getMCPCompatibleErrorMessage(error) };
+        event.error = captureException(error);
         event.isError = true;
         event.duration =
           (event.timestamp &&

--- a/src/modules/tracing.ts
+++ b/src/modules/tracing.ts
@@ -15,7 +15,6 @@ import { getServerTrackingData, handleIdentify } from "./internal.js";
 import { getServerSessionId } from "./session.js";
 import { PublishEventRequestEventTypeEnum } from "mcpcat-api";
 import { publishEvent } from "./eventQueue.js";
-import { getMCPCompatibleErrorMessage } from "./compatibility.js";
 import { captureException } from "./exceptions.js";
 import { addContextParameterToTools } from "./context-parameters.js";
 import {
@@ -95,7 +94,7 @@ export function setupListToolsTracing(
         writeToLog(
           `Warning: Original list tools handler failed, this suggests an error MCPCat did not cause - ${error}`,
         );
-        event.error = { message: getMCPCompatibleErrorMessage(error) };
+        event.error = captureException(error);
         event.isError = true;
         event.duration =
           (event.timestamp &&


### PR DESCRIPTION
## Summary
- Replace `getMCPCompatibleErrorMessage` with `captureException` in both `tools.ts` and `tracing.ts`
- Ensures consistent error handling when the original list tools handler fails
- Centralizes error structure through the existing exception handler utility

## Test plan
- [ ] Run test suite: `pnpm test`
- [ ] Verify error handling still produces properly structured error objects
- [ ] Confirm no regression in list tools functionality