### PR TITLE
chore: upgrade mcpcat-api to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@opentelemetry/otlp-transformer": "^0.203.0",
-    "mcpcat-api": "0.1.6"
+    "mcpcat-api": "0.1.7"
   },
   "lint-staged": {
     "*.{ts,js}": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcpcat",
-  "version": "0.1.11",
+  "version": "0.1.12-beta.0",
   "description": "Analytics tool for MCP (Model Context Protocol) servers - tracks tool usage patterns and provides insights",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcpcat",
-  "version": "0.1.12-beta.0",
+  "version": "0.1.12",
   "description": "Analytics tool for MCP (Model Context Protocol) servers - tracks tool usage patterns and provides insights",
   "type": "module",
   "main": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.203.0
         version: 0.203.0(@opentelemetry/api@1.9.0)
       mcpcat-api:
-        specifier: 0.1.6
-        version: 0.1.6
+        specifier: 0.1.7
+        version: 0.1.7
     devDependencies:
       "@changesets/cli":
         specifier: ^2.29.8
@@ -2610,10 +2610,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  mcpcat-api@0.1.6:
+  mcpcat-api@0.1.7:
     resolution:
       {
-        integrity: sha512-jNnPMBa5mLClghI+KLVFwYzOTL6G02kGIut4qGzso+GgLjHYOQ7x7zy0Cw0Pkx1MCb1JMwxF8yJ76xgEwuopNQ==,
+        integrity: sha512-c8kJ5rQ68xYFT8O3bbsu68WzGEzGbmmYVcD87YuvlNRof8iy+2vM8uRuZ4kO3OEUTeDA/FA4kgI+DCjOAeO7sw==,
       }
 
   media-typer@1.1.0:
@@ -5244,7 +5244,7 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcpcat-api@0.1.6: {}
+  mcpcat-api@0.1.7: {}
 
   media-typer@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- Upgrade `mcpcat-api` dependency from 0.1.6 to 0.1.7 to fix ESM module resolution errors
- Lockfile updated accordingly (formatting changes from pnpm regeneration)

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm run build` produces ESM, CJS, and DTS outputs without errors
- [x] `pnpm test` — 286 tests pass, 0 failures
- [x] `pnpm run typecheck` — no type errors
- [x] `pnpm run lint` — no lint errors
- [x] CJS `require('mcpcat-api')` resolves correctly
- [x] ESM `import('mcpcat-api')` resolves correctly
- [x] Built SDK ESM import (`dist/index.mjs`) works
- [x] Built SDK CJS require (`dist/index.cjs`) works