### PR TITLE
feat: Add content sanitization for non-text MCP data types

### DIFF
--- a/src/modules/eventQueue.ts
+++ b/src/modules/eventQueue.ts
@@ -9,6 +9,7 @@ import { writeToLog } from "./logging.js";
 import { getServerTrackingData } from "./internal.js";
 import { getSessionInfo } from "./session.js";
 import { redactEvent } from "./redaction.js";
+import { sanitizeEvent } from "./sanitization.js";
 import KSUID from "../thirdparty/ksuid/index.js";
 import { getMCPCompatibleErrorMessage } from "./compatibility.js";
 import { TelemetryManager } from "./telemetry.js";
@@ -50,27 +51,27 @@ class EventQueue {
 
     while (this.queue.length > 0 && this.activeRequests < this.concurrency) {
       const event = this.queue.shift();
-      if (event?.redactionFn) {
-        // Redact sensitive information if a redaction function is provided
+      if (!event) continue;
+
+      if (event.redactionFn) {
         try {
           const redactedEvent = await redactEvent(event, event.redactionFn);
-          event.redactionFn = undefined; // Clear the function to avoid reprocessing
+          event.redactionFn = undefined;
           Object.assign(event, redactedEvent);
         } catch (error) {
           writeToLog(`Failed to redact event: ${error}`);
-          continue; // Skip this event if redaction fails
+          continue;
         }
       }
 
-      if (event) {
-        event.id = event.id || (await KSUID.withPrefix("evt").random());
-        this.activeRequests++;
-        this.sendEvent(event as Event).finally(() => {
-          this.activeRequests--;
-          // Try to process more events
-          this.process();
-        });
-      }
+      Object.assign(event, sanitizeEvent(event));
+
+      event.id = event.id || (await KSUID.withPrefix("evt").random());
+      this.activeRequests++;
+      this.sendEvent(event as Event).finally(() => {
+        this.activeRequests--;
+        this.process();
+      });
     }
 
     this.processing = false;

--- a/src/modules/eventQueue.ts
+++ b/src/modules/eventQueue.ts
@@ -64,7 +64,12 @@ class EventQueue {
         }
       }
 
-      Object.assign(event, sanitizeEvent(event));
+      try {
+        Object.assign(event, sanitizeEvent(event));
+      } catch (error) {
+        writeToLog(`Failed to sanitize event: ${error}`);
+        continue;
+      }
 
       event.id = event.id || (await KSUID.withPrefix("evt").random());
       this.activeRequests++;

--- a/src/modules/sanitization.ts
+++ b/src/modules/sanitization.ts
@@ -1,0 +1,138 @@
+import { Event, UnredactedEvent } from "../types.js";
+
+const BASE64_PATTERN = /^[A-Za-z0-9+/\n\r]+=*$/;
+const SIZE_GATE = 10240; // 10KB - skip strings shorter than this
+
+/**
+ * Sanitizes an event by redacting non-text content blocks from responses
+ * and large base64-encoded strings from parameters.
+ *
+ * This is a synchronous operation that returns a new object without mutating the original.
+ * It should run after customer redaction in the event pipeline.
+ */
+export function sanitizeEvent<T extends Event | UnredactedEvent>(event: T): T {
+  const result = { ...event };
+
+  if (result.response != null) {
+    result.response = sanitizeResponse(result.response);
+  }
+
+  if (result.parameters != null) {
+    result.parameters = sanitizeParameters(result.parameters);
+  }
+
+  return result;
+}
+
+/**
+ * Sanitizes response content blocks by replacing non-text content types
+ * with informative redaction messages.
+ */
+function sanitizeResponse(response: any): any {
+  if (response == null || typeof response !== "object") {
+    return response;
+  }
+
+  const result = { ...response };
+
+  if (Array.isArray(result.content)) {
+    result.content = result.content.map(sanitizeContentBlock);
+  }
+
+  if (
+    result.structuredContent != null &&
+    typeof result.structuredContent === "object"
+  ) {
+    result.structuredContent = sanitizeParameters(result.structuredContent);
+  }
+
+  return result;
+}
+
+/**
+ * Sanitizes a single content block based on its type discriminator.
+ */
+function sanitizeContentBlock(block: any): any {
+  if (block == null || typeof block !== "object") {
+    return block;
+  }
+
+  switch (block.type) {
+    case "text":
+      return block;
+
+    case "image":
+      return {
+        type: "text",
+        text: "[image content redacted - not supported by MCPcat]",
+      };
+
+    case "audio":
+      return {
+        type: "text",
+        text: "[audio content redacted - not supported by MCPcat]",
+      };
+
+    case "resource":
+      return sanitizeResourceBlock(block);
+
+    case "resource_link":
+      return block;
+
+    default:
+      return {
+        type: "text",
+        text: `[unsupported content type "${block.type}" redacted - not supported by MCPcat]`,
+      };
+  }
+}
+
+/**
+ * Sanitizes an embedded resource content block.
+ * BlobResourceContents (has `blob` field) are redacted.
+ * TextResourceContents (has `text` field) pass through.
+ */
+function sanitizeResourceBlock(block: any): any {
+  if (block.resource && block.resource.blob !== undefined) {
+    return {
+      type: "text",
+      text: "[binary resource content redacted - not supported by MCPcat]",
+    };
+  }
+  return block;
+}
+
+/**
+ * Recursively scans parameters for large base64-encoded strings and replaces them.
+ * Uses a size gate (10KB) to avoid regex testing on small strings.
+ */
+function sanitizeParameters(obj: any): any {
+  if (obj == null) {
+    return obj;
+  }
+
+  if (typeof obj === "string") {
+    if (obj.length >= SIZE_GATE && BASE64_PATTERN.test(obj)) {
+      return "[binary data redacted - not supported by MCPcat]";
+    }
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeParameters);
+  }
+
+  if (obj instanceof Date) {
+    return obj;
+  }
+
+  if (typeof obj === "object") {
+    const result: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = sanitizeParameters(value);
+    }
+    return result;
+  }
+
+  return obj;
+}

--- a/src/tests/sanitization.test.ts
+++ b/src/tests/sanitization.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeEvent } from "../modules/sanitization.js";
+import { Event } from "../types.js";
+
+function makeLargeBase64(sizeInChars = 12000): string {
+  return "A".repeat(sizeInChars - 1) + "=";
+}
+
+function makeLargeNonBase64(sizeInChars = 12000): string {
+  return "Hello, world! This is NOT base64. ".repeat(
+    Math.ceil(sizeInChars / 34),
+  );
+}
+
+function makeEvent(overrides: Partial<Event>): Event {
+  return {
+    id: "evt_1",
+    sessionId: "ses_1",
+    eventType: "mcp:tools/call",
+    timestamp: new Date(),
+    ...overrides,
+  } as Event;
+}
+
+describe("sanitizeEvent - response content blocks", () => {
+  it("should replace image and audio blocks but keep text blocks", () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          { type: "text", text: "Hello world" },
+          { type: "image", data: "base64imagedata...", mimeType: "image/png" },
+          { type: "audio", data: "base64audiodata...", mimeType: "audio/wav" },
+        ],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content).toHaveLength(3);
+    expect(result.response.content[0]).toEqual({
+      type: "text",
+      text: "Hello world",
+    });
+    expect(result.response.content[1]).toEqual({
+      type: "text",
+      text: "[image content redacted - not supported by MCPcat]",
+    });
+    expect(result.response.content[2]).toEqual({
+      type: "text",
+      text: "[audio content redacted - not supported by MCPcat]",
+    });
+  });
+
+  it("should leave text-only content unchanged", () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          { type: "text", text: "First" },
+          { type: "text", text: "Second" },
+        ],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content).toEqual([
+      { type: "text", text: "First" },
+      { type: "text", text: "Second" },
+    ]);
+  });
+
+  it("should redact EmbeddedResource with blob", () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          {
+            type: "resource",
+            resource: {
+              uri: "file:///data.bin",
+              blob: "base64blobdata...",
+              mimeType: "application/octet-stream",
+            },
+          },
+        ],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content[0]).toEqual({
+      type: "text",
+      text: "[binary resource content redacted - not supported by MCPcat]",
+    });
+  });
+
+  it("should pass through EmbeddedResource with text", () => {
+    const textResource = {
+      type: "resource",
+      resource: {
+        uri: "file:///readme.txt",
+        text: "This is a text resource",
+        mimeType: "text/plain",
+      },
+    };
+
+    const event = makeEvent({
+      response: { content: [textResource] },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content[0]).toEqual(textResource);
+  });
+
+  it("should redact unknown content types with type name in message", () => {
+    const event = makeEvent({
+      response: {
+        content: [{ type: "video", data: "somestuff", mimeType: "video/mp4" }],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content[0]).toEqual({
+      type: "text",
+      text: '[unsupported content type "video" redacted - not supported by MCPcat]',
+    });
+  });
+
+  it("should pass through resource_link unchanged", () => {
+    const resourceLink = {
+      type: "resource_link",
+      uri: "file:///some/resource",
+      name: "My Resource",
+    };
+
+    const event = makeEvent({
+      response: { content: [resourceLink] },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content[0]).toEqual(resourceLink);
+  });
+
+  it("should redact large base64 inside structuredContent", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      response: {
+        structuredContent: {
+          data: largeBase64,
+          label: "some label",
+        },
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.structuredContent.data).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.response.structuredContent.label).toBe("some label");
+  });
+
+  it("should handle response without content array", () => {
+    const event = makeEvent({
+      response: { result: "success" },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response).toEqual({ result: "success" });
+  });
+
+  it("should handle null and undefined response without error", () => {
+    const resultNull = sanitizeEvent(makeEvent({ response: null }));
+    const resultUndef = sanitizeEvent(makeEvent({ response: undefined }));
+
+    expect(resultNull.response).toBeNull();
+    expect(resultUndef.response).toBeUndefined();
+  });
+});
+
+describe("sanitizeEvent - parameter scanning", () => {
+  it("should leave small strings unchanged", () => {
+    const event = makeEvent({
+      parameters: {
+        name: "hello",
+        query: "some query text",
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters).toEqual({
+      name: "hello",
+      query: "some query text",
+    });
+  });
+
+  it("should redact large base64 strings (>10KB)", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      parameters: { imageData: largeBase64 },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.imageData).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+  });
+
+  it("should leave large non-base64 strings unchanged", () => {
+    const largeText = makeLargeNonBase64();
+
+    const event = makeEvent({
+      parameters: { longText: largeText },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.longText).toBe(largeText);
+  });
+
+  it("should find and redact deeply nested large base64", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      parameters: {
+        level1: {
+          level2: {
+            level3: { data: largeBase64 },
+          },
+        },
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.level1.level2.level3.data).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+  });
+
+  it("should only redact large base64 in mixed-type parameters", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      parameters: {
+        count: 42,
+        active: true,
+        name: "short string",
+        binaryData: largeBase64,
+        tags: ["a", "b", "c"],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.count).toBe(42);
+    expect(result.parameters.active).toBe(true);
+    expect(result.parameters.name).toBe("short string");
+    expect(result.parameters.binaryData).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.parameters.tags).toEqual(["a", "b", "c"]);
+  });
+
+  it("should redact large base64 inside an array", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      parameters: {
+        items: ["small string", largeBase64, "another small"],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.items[0]).toBe("small string");
+    expect(result.parameters.items[1]).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.parameters.items[2]).toBe("another small");
+  });
+
+  it("should redact base64 string at exactly SIZE_GATE boundary (10240 chars)", () => {
+    const exactBoundary = makeLargeBase64(10240);
+    const belowBoundary = makeLargeBase64(10239);
+
+    const event = makeEvent({
+      parameters: {
+        atGate: exactBoundary,
+        belowGate: belowBoundary,
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.atGate).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.parameters.belowGate).toBe(belowBoundary);
+  });
+
+  it("should handle null and undefined parameters without error", () => {
+    const resultNull = sanitizeEvent(makeEvent({ parameters: null }));
+    const resultUndef = sanitizeEvent(makeEvent({ parameters: undefined }));
+
+    expect(resultNull.parameters).toBeNull();
+    expect(resultUndef.parameters).toBeUndefined();
+  });
+});
+
+describe("sanitizeEvent - integration", () => {
+  it("should sanitize both parameters and response in a full event", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      projectId: "proj_1",
+      resourceName: "my-tool",
+      parameters: {
+        imageData: largeBase64,
+        query: "hello",
+      },
+      response: {
+        content: [
+          { type: "text", text: "Result text" },
+          { type: "image", data: "base64img", mimeType: "image/png" },
+        ],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.imageData).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.parameters.query).toBe("hello");
+
+    expect(result.response.content[0]).toEqual({
+      type: "text",
+      text: "Result text",
+    });
+    expect(result.response.content[1]).toEqual({
+      type: "text",
+      text: "[image content redacted - not supported by MCPcat]",
+    });
+
+    expect(result.id).toBe("evt_1");
+    expect(result.sessionId).toBe("ses_1");
+    expect(result.projectId).toBe("proj_1");
+    expect(result.resourceName).toBe("my-tool");
+  });
+
+  it("should not mutate the original event", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      parameters: { imageData: largeBase64 },
+      response: {
+        content: [{ type: "image", data: "base64img", mimeType: "image/png" }],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    // Original should be unchanged
+    expect(event.parameters.imageData).toBe(largeBase64);
+    expect(event.response.content[0].type).toBe("image");
+    expect(event.response.content[0].data).toBe("base64img");
+
+    // Result should be different
+    expect(result.parameters.imageData).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.response.content[0].type).toBe("text");
+  });
+});


### PR DESCRIPTION
## Summary
- Add two-layer content sanitization to detect and redact non-text data from events before they reach the MCPCat API and telemetry exporters
- **Layer 1 (Response):** Replace non-text content blocks (image, audio, blob resources, unknown types) with informative redaction messages while passing through text and resource_link blocks
- **Layer 2 (Parameters):** Recursively scan parameters for large base64-encoded strings (>=10KB size gate) and redact them

## Test plan
- [x] Run full test suite: `pnpm test` (321 passing, 0 regressions)
- [x] Run sanitization tests: `pnpm test src/tests/sanitization.test.ts` (19 tests covering response blocks, parameter scanning, structuredContent, boundary conditions, and immutability)
- [ ] Verify an MCP server returning `ImageContent` in a tool response logs the redaction message in `~/mcpcat.log` instead of base64 data