### PR TITLE
feat: Add client-side event truncation (100KB max)

### DIFF
--- a/docs/plans/2026-02-25-event-truncation-design.md
+++ b/docs/plans/2026-02-25-event-truncation-design.md
@@ -1,0 +1,120 @@
+# Event Truncation Design
+
+## Problem
+
+The MCPCat backend needs protection from oversized event payloads. Currently, user-controlled fields (`parameters`, `response`, `identifyActorData`, `error`, `userIntent`) have no size limits. A single event could contain megabytes of text, deeply nested objects, or thousands of properties.
+
+## Approach: Full Sentry-Style Normalization
+
+Three layers of truncation applied in sequence, guaranteeing no event exceeds 100KB.
+
+### Pipeline Position
+
+```
+event dequeued
+  -> customer redaction (if configured)   [Layer 1: redaction.ts]
+  -> content sanitization                 [Layer 2: sanitization.ts]
+  -> event truncation                     [Layer 3: truncation.ts - NEW]
+  -> generate event ID
+  -> send to API / exporters
+```
+
+New file: `src/modules/truncation.ts`
+Integration point: `src/modules/eventQueue.ts` (after `sanitizeEvent()`)
+
+### Contract
+
+- Synchronous (no async)
+- Pure function — returns new object, never mutates input
+- Handles null/undefined gracefully
+- Applied unconditionally to every event
+- All limits hard-coded (no configuration surface)
+
+## Layer 1: Field-Level Limits
+
+| Field                                                        | Limit                          | Marker |
+| ------------------------------------------------------------ | ------------------------------ | ------ |
+| `userIntent`                                                 | 2,048 chars                    | `...`  |
+| `response.content[].text`                                    | 32,768 chars (32KB)            | `...`  |
+| `error.message`                                              | 2,048 chars                    | `...`  |
+| `error.frames[]`                                             | 50 frames (first 25 + last 25) | —      |
+| `resourceName`                                               | 256 chars                      | `...`  |
+| `serverName`, `serverVersion`, `clientName`, `clientVersion` | 256 chars each                 | `...`  |
+
+## Layer 2: Recursive Object Normalization
+
+Applied to user-controlled object fields only:
+
+- `parameters`
+- `response`
+- `identifyActorData`
+- `error`
+
+### Parameters (hard-coded)
+
+| Parameter         | Value                    |
+| ----------------- | ------------------------ |
+| Max depth         | 10                       |
+| Max breadth       | 100 properties per level |
+| Max string length | 32,768 chars (32KB)      |
+
+### Behaviors
+
+1. **Depth limiting:** Objects/arrays beyond max depth -> `"[Object]"` / `"[Array]"`
+2. **Breadth limiting:** Properties beyond max -> `"[MaxProperties ~]"` sentinel
+3. **Circular references:** WeakSet detection -> `"[Circular ~]"`
+4. **String truncation:** Exceeding max length -> truncated with `...`
+5. **Non-serializable values:**
+   - Functions -> `"[Function: name]"`
+   - Symbols -> `"[Symbol(description)]"`
+   - `undefined` -> `"[undefined]"`
+   - `BigInt` -> `"[BigInt: value]"`
+   - `NaN` / `Infinity` -> `"[NaN]"` / `"[Infinity]"`
+6. **Date objects:** -> ISO string
+
+### Fields NOT normalized (SDK-controlled)
+
+`id`, `sessionId`, `projectId`, `eventType`, `timestamp`, `duration`, `sdkLanguage`, `mcpcatVersion`, `ipAddress`, `isError`
+
+## Layer 3: Size-Targeted Normalization
+
+Final safety net guaranteeing 100KB max event size.
+
+```
+truncateToSize(event, maxBytes = 102_400):
+    normalized = applyNormalization(event, depth=10)
+
+    while jsonByteSize(normalized) > maxBytes AND depth > 1:
+        depth -= 1
+        normalized = applyNormalization(event, depth)
+
+    if jsonByteSize(normalized) > maxBytes:
+        truncateLargestFields(normalized, maxBytes)
+
+    return normalized
+```
+
+Progressive depth reduction preserves top-level structure while collapsing deeply nested details first.
+
+## Test Plan
+
+File: `src/tests/truncation.test.ts`
+
+1. String truncation — fields exceeding limits get `...` appended
+2. Stack frame limiting — >50 frames trimmed to first 25 + last 25
+3. Depth limiting — deeply nested objects get `[Object]` / `[Array]` markers
+4. Breadth limiting — wide objects get `[MaxProperties ~]` sentinel
+5. Circular reference detection — cycles get `[Circular ~]` marker
+6. Non-serializable values — functions, symbols, BigInt get descriptive strings
+7. Size targeting — events >100KB get progressively reduced
+8. Non-mutation — original event object is never modified
+9. Integration — sanitization + truncation pipeline works end-to-end
+10. Edge cases — null/undefined fields, empty events, already-small events pass unchanged
+
+## Design Principles (from Sentry)
+
+1. **Truncate early, client-side** — reduces network, server, and storage costs simultaneously
+2. **Preserve what matters most** — top-level structure over deeply nested details
+3. **Mark, don't silently drop** — every truncation leaves a visible marker
+4. **Hard-coded where reasonable** — no configuration surface; can add later if customers ask
+5. **Defense in depth** — three independent layers (field limits, normalization, size target)

--- a/docs/plans/2026-02-25-event-truncation-plan.md
+++ b/docs/plans/2026-02-25-event-truncation-plan.md
@@ -1,0 +1,1158 @@
+# Event Truncation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Sentry-style client-side event truncation to guarantee no event exceeds 100KB before being sent to the MCPCat API.
+
+**Architecture:** A new `truncateEvent()` function in `src/modules/truncation.ts` applies three layers: field-level limits, recursive object normalization (depth/breadth/circular-ref), and size-targeted fallback. It runs after `sanitizeEvent()` in the event queue pipeline.
+
+**Tech Stack:** TypeScript, Vitest for testing, no new dependencies.
+
+---
+
+### Task 1: Core normalize() function — string truncation + non-serializable values
+
+**Files:**
+
+- Create: `src/modules/truncation.ts`
+- Create: `src/tests/truncation.test.ts`
+
+**Step 1: Write the failing tests**
+
+In `src/tests/truncation.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { normalize } from "../modules/truncation.js";
+
+describe("normalize - string truncation", () => {
+  it("should leave short strings unchanged", () => {
+    expect(normalize("hello")).toBe("hello");
+  });
+
+  it("should truncate strings exceeding maxStringLength with '...'", () => {
+    const long = "a".repeat(33000);
+    const result = normalize(long) as string;
+    expect(result.length).toBe(32768 + 3); // 32KB + "..."
+    expect(result.endsWith("...")).toBe(true);
+    expect(result.startsWith("a".repeat(100))).toBe(true);
+  });
+
+  it("should leave strings at exactly maxStringLength unchanged", () => {
+    const exact = "a".repeat(32768);
+    expect(normalize(exact)).toBe(exact);
+  });
+});
+
+describe("normalize - non-serializable values", () => {
+  it("should convert functions to descriptive string", () => {
+    function myFunc() {}
+    expect(normalize(myFunc)).toBe("[Function: myFunc]");
+  });
+
+  it("should convert anonymous functions", () => {
+    expect(normalize(() => {})).toBe("[Function: <anonymous>]");
+  });
+
+  it("should convert symbols", () => {
+    expect(normalize(Symbol("test"))).toBe("[Symbol(test)]");
+    expect(normalize(Symbol())).toBe("[Symbol()]");
+  });
+
+  it("should convert undefined to string marker", () => {
+    expect(normalize(undefined)).toBe("[undefined]");
+  });
+
+  it("should convert BigInt to string marker", () => {
+    expect(normalize(BigInt(123))).toBe("[BigInt: 123]");
+  });
+
+  it("should convert NaN to string marker", () => {
+    expect(normalize(NaN)).toBe("[NaN]");
+  });
+
+  it("should convert Infinity to string marker", () => {
+    expect(normalize(Infinity)).toBe("[Infinity]");
+    expect(normalize(-Infinity)).toBe("[-Infinity]");
+  });
+
+  it("should convert Date to ISO string", () => {
+    const date = new Date("2025-01-15T12:00:00Z");
+    expect(normalize(date)).toBe("2025-01-15T12:00:00.000Z");
+  });
+
+  it("should pass through numbers unchanged", () => {
+    expect(normalize(42)).toBe(42);
+    expect(normalize(0)).toBe(0);
+    expect(normalize(-3.14)).toBe(-3.14);
+  });
+
+  it("should pass through booleans unchanged", () => {
+    expect(normalize(true)).toBe(true);
+    expect(normalize(false)).toBe(false);
+  });
+
+  it("should pass through null as null", () => {
+    expect(normalize(null)).toBeNull();
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/tests/truncation.test.ts`
+Expected: FAIL — `normalize` doesn't exist yet
+
+**Step 3: Write minimal implementation**
+
+In `src/modules/truncation.ts`:
+
+```typescript
+import { Event, UnredactedEvent } from "../types.js";
+
+// --- Constants ---
+const MAX_DEPTH = 10;
+const MAX_BREADTH = 100;
+const MAX_STRING_LENGTH = 32_768; // 32KB
+const MAX_EVENT_BYTES = 102_400; // 100KB
+
+// --- Truncation markers ---
+const TRUNCATION_SUFFIX = "...";
+
+/**
+ * Recursively normalizes a value, handling:
+ * - String truncation (> MAX_STRING_LENGTH)
+ * - Non-serializable values (functions, symbols, undefined, BigInt, NaN, Infinity)
+ * - Date objects -> ISO string
+ * - Circular reference detection
+ * - Depth limiting
+ * - Breadth limiting
+ */
+export function normalize(
+  input: unknown,
+  depth: number = MAX_DEPTH,
+  maxBreadth: number = MAX_BREADTH,
+  maxStringLength: number = MAX_STRING_LENGTH,
+): unknown {
+  const memo = new WeakSet<object>();
+  return visit(input, depth, maxBreadth, maxStringLength, memo);
+}
+
+function visit(
+  value: unknown,
+  remainingDepth: number,
+  maxBreadth: number,
+  maxStringLength: number,
+  memo: WeakSet<object>,
+): unknown {
+  // null
+  if (value === null) return null;
+
+  // undefined
+  if (value === undefined) return "[undefined]";
+
+  // boolean
+  if (typeof value === "boolean") return value;
+
+  // number (including NaN, Infinity)
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) return "[NaN]";
+    if (!Number.isFinite(value))
+      return value > 0 ? "[Infinity]" : "[-Infinity]";
+    return value;
+  }
+
+  // bigint
+  if (typeof value === "bigint") return `[BigInt: ${value}]`;
+
+  // string
+  if (typeof value === "string") {
+    if (value.length > maxStringLength) {
+      return value.slice(0, maxStringLength) + TRUNCATION_SUFFIX;
+    }
+    return value;
+  }
+
+  // symbol
+  if (typeof value === "symbol") {
+    const desc = value.description;
+    return desc ? `[Symbol(${desc})]` : "[Symbol()]";
+  }
+
+  // function
+  if (typeof value === "function") {
+    const name = value.name || "<anonymous>";
+    return `[Function: ${name}]`;
+  }
+
+  // Date
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  // Objects and arrays from here — need depth/breadth/circular checks
+  if (typeof value === "object") {
+    // Circular reference detection
+    if (memo.has(value)) return "[Circular ~]";
+
+    // Depth limit
+    if (remainingDepth <= 0) {
+      return Array.isArray(value) ? "[Array]" : "[Object]";
+    }
+
+    memo.add(value);
+
+    let result: unknown;
+    if (Array.isArray(value)) {
+      result = visitArray(
+        value,
+        remainingDepth - 1,
+        maxBreadth,
+        maxStringLength,
+        memo,
+      );
+    } else {
+      result = visitObject(
+        value as Record<string, unknown>,
+        remainingDepth - 1,
+        maxBreadth,
+        maxStringLength,
+        memo,
+      );
+    }
+
+    memo.delete(value);
+    return result;
+  }
+
+  // Fallback: coerce to string
+  return String(value);
+}
+
+function visitArray(
+  arr: unknown[],
+  remainingDepth: number,
+  maxBreadth: number,
+  maxStringLength: number,
+  memo: WeakSet<object>,
+): unknown[] {
+  const result: unknown[] = [];
+  for (let i = 0; i < arr.length; i++) {
+    if (i >= maxBreadth) {
+      result.push("[MaxProperties ~]");
+      break;
+    }
+    result.push(
+      visit(arr[i], remainingDepth, maxBreadth, maxStringLength, memo),
+    );
+  }
+  return result;
+}
+
+function visitObject(
+  obj: Record<string, unknown>,
+  remainingDepth: number,
+  maxBreadth: number,
+  maxStringLength: number,
+  memo: WeakSet<object>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const keys = Object.keys(obj);
+  let count = 0;
+
+  for (const key of keys) {
+    if (count >= maxBreadth) {
+      result["..."] = "[MaxProperties ~]";
+      break;
+    }
+    result[key] = visit(
+      obj[key],
+      remainingDepth,
+      maxBreadth,
+      maxStringLength,
+      memo,
+    );
+    count++;
+  }
+
+  return result;
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/tests/truncation.test.ts`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/modules/truncation.ts src/tests/truncation.test.ts
+git commit -m "feat: add normalize() with string truncation + non-serializable value handling"
+```
+
+---
+
+### Task 2: normalize() — depth limiting, breadth limiting, circular reference detection
+
+**Files:**
+
+- Modify: `src/tests/truncation.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add to `src/tests/truncation.test.ts`:
+
+```typescript
+describe("normalize - depth limiting", () => {
+  it("should collapse objects beyond max depth to '[Object]'", () => {
+    // Build a deeply nested object: { a: { a: { a: ... } } }
+    let obj: any = { value: "deep" };
+    for (let i = 0; i < 15; i++) {
+      obj = { nested: obj };
+    }
+    const result = normalize(obj, 5) as any;
+    // At depth 5, we can access 5 levels then it collapses
+    expect(result.nested.nested.nested.nested.nested).toBe("[Object]");
+  });
+
+  it("should collapse arrays beyond max depth to '[Array]'", () => {
+    let arr: any = ["leaf"];
+    for (let i = 0; i < 15; i++) {
+      arr = [arr];
+    }
+    const result = normalize(arr, 3) as any;
+    expect(result[0][0][0]).toBe("[Array]");
+  });
+
+  it("should handle depth=0 by collapsing top-level objects", () => {
+    expect(normalize({ a: 1 }, 0)).toBe("[Object]");
+    expect(normalize([1, 2], 0)).toBe("[Array]");
+  });
+
+  it("should not collapse primitives regardless of depth", () => {
+    expect(normalize("hello", 0)).toBe("hello");
+    expect(normalize(42, 0)).toBe(42);
+  });
+});
+
+describe("normalize - breadth limiting", () => {
+  it("should limit object properties to maxBreadth", () => {
+    const wide: Record<string, number> = {};
+    for (let i = 0; i < 150; i++) {
+      wide[`key${i}`] = i;
+    }
+    const result = normalize(wide, 10, 5) as Record<string, unknown>;
+    const keys = Object.keys(result);
+    // 5 real keys + 1 sentinel key
+    expect(keys.length).toBe(6);
+    expect(result["..."]).toBe("[MaxProperties ~]");
+  });
+
+  it("should limit array elements to maxBreadth", () => {
+    const wide = Array.from({ length: 150 }, (_, i) => i);
+    const result = normalize(wide, 10, 5) as unknown[];
+    // 5 real elements + 1 sentinel
+    expect(result.length).toBe(6);
+    expect(result[5]).toBe("[MaxProperties ~]");
+  });
+
+  it("should leave objects within breadth limit unchanged", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = normalize(obj, 10, 100) as Record<string, unknown>;
+    expect(result).toEqual({ a: 1, b: 2, c: 3 });
+  });
+});
+
+describe("normalize - circular reference detection", () => {
+  it("should detect circular object references", () => {
+    const obj: any = { a: 1 };
+    obj.self = obj;
+    const result = normalize(obj) as any;
+    expect(result.a).toBe(1);
+    expect(result.self).toBe("[Circular ~]");
+  });
+
+  it("should detect circular array references", () => {
+    const arr: any[] = [1, 2];
+    arr.push(arr);
+    const result = normalize(arr) as any;
+    expect(result[0]).toBe(1);
+    expect(result[1]).toBe(2);
+    expect(result[2]).toBe("[Circular ~]");
+  });
+
+  it("should allow same object in different branches (not a cycle)", () => {
+    const shared = { value: "shared" };
+    const obj = { a: shared, b: shared };
+    const result = normalize(obj) as any;
+    expect(result.a).toEqual({ value: "shared" });
+    expect(result.b).toEqual({ value: "shared" });
+  });
+
+  it("should detect deeply nested circular references", () => {
+    const obj: any = { level1: { level2: { level3: {} } } };
+    obj.level1.level2.level3.backToRoot = obj;
+    const result = normalize(obj) as any;
+    expect(result.level1.level2.level3.backToRoot).toBe("[Circular ~]");
+  });
+});
+```
+
+**Step 2: Run tests to verify they pass (they should already pass since Task 1 implemented the full normalize)**
+
+Run: `pnpm vitest run src/tests/truncation.test.ts`
+Expected: All PASS (normalize already handles depth, breadth, and circular refs)
+
+**Step 3: Commit**
+
+```bash
+git add src/tests/truncation.test.ts
+git commit -m "test: add depth, breadth, and circular reference tests for normalize()"
+```
+
+---
+
+### Task 3: Field-level truncation — truncateEvent() top-level function
+
+**Files:**
+
+- Modify: `src/modules/truncation.ts`
+- Modify: `src/tests/truncation.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add to `src/tests/truncation.test.ts`:
+
+```typescript
+import { truncateEvent } from "../modules/truncation.js";
+import { Event, StackFrame } from "../types.js";
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: "evt_1",
+    sessionId: "ses_1",
+    eventType: "mcp:tools/call",
+    timestamp: new Date("2025-01-15T12:00:00Z"),
+    ...overrides,
+  } as Event;
+}
+
+describe("truncateEvent - field-level string limits", () => {
+  it("should truncate userIntent exceeding 2048 chars", () => {
+    const event = makeEvent({ userIntent: "x".repeat(3000) });
+    const result = truncateEvent(event);
+    expect(result.userIntent!.length).toBe(2048 + 3);
+    expect(result.userIntent!.endsWith("...")).toBe(true);
+  });
+
+  it("should truncate resourceName exceeding 256 chars", () => {
+    const event = makeEvent({ resourceName: "t".repeat(300) });
+    const result = truncateEvent(event);
+    expect(result.resourceName!.length).toBe(256 + 3);
+    expect(result.resourceName!.endsWith("...")).toBe(true);
+  });
+
+  it("should truncate serverName, serverVersion, clientName, clientVersion exceeding 256 chars", () => {
+    const event = makeEvent({
+      serverName: "s".repeat(300),
+      serverVersion: "v".repeat(300),
+      clientName: "c".repeat(300),
+      clientVersion: "cv".repeat(200),
+    });
+    const result = truncateEvent(event);
+    expect(result.serverName!.length).toBe(256 + 3);
+    expect(result.serverVersion!.length).toBe(256 + 3);
+    expect(result.clientName!.length).toBe(256 + 3);
+    expect(result.clientVersion!.length).toBe(256 + 3);
+  });
+
+  it("should leave short field values unchanged", () => {
+    const event = makeEvent({
+      userIntent: "Get weather",
+      resourceName: "fetch_weather",
+      serverName: "my-server",
+    });
+    const result = truncateEvent(event);
+    expect(result.userIntent).toBe("Get weather");
+    expect(result.resourceName).toBe("fetch_weather");
+    expect(result.serverName).toBe("my-server");
+  });
+
+  it("should handle undefined/null fields gracefully", () => {
+    const event = makeEvent({
+      userIntent: undefined,
+      resourceName: undefined,
+      serverName: undefined,
+    });
+    const result = truncateEvent(event);
+    expect(result.userIntent).toBeUndefined();
+    expect(result.resourceName).toBeUndefined();
+    expect(result.serverName).toBeUndefined();
+  });
+});
+
+describe("truncateEvent - error field limits", () => {
+  it("should truncate error.message exceeding 2048 chars", () => {
+    const event = makeEvent({
+      error: {
+        message: "e".repeat(3000),
+        type: "Error",
+      },
+    });
+    const result = truncateEvent(event);
+    expect(result.error!.message.length).toBe(2048 + 3);
+    expect(result.error!.message.endsWith("...")).toBe(true);
+  });
+
+  it("should limit error.frames to 50 (first 25 + last 25)", () => {
+    const frames: StackFrame[] = Array.from({ length: 80 }, (_, i) => ({
+      filename: `file${i}.ts`,
+      function: `func${i}`,
+      lineno: i + 1,
+      in_app: true,
+    }));
+    const event = makeEvent({
+      error: { message: "test", frames },
+    });
+    const result = truncateEvent(event);
+    expect(result.error!.frames!.length).toBe(50);
+    // First 25 should be from the start
+    expect(result.error!.frames![0].filename).toBe("file0.ts");
+    expect(result.error!.frames![24].filename).toBe("file24.ts");
+    // Last 25 should be from the end
+    expect(result.error!.frames![25].filename).toBe("file55.ts");
+    expect(result.error!.frames![49].filename).toBe("file79.ts");
+  });
+
+  it("should leave frames at exactly 50 unchanged", () => {
+    const frames: StackFrame[] = Array.from({ length: 50 }, (_, i) => ({
+      filename: `file${i}.ts`,
+      function: `func${i}`,
+      in_app: true,
+    }));
+    const event = makeEvent({
+      error: { message: "test", frames },
+    });
+    const result = truncateEvent(event);
+    expect(result.error!.frames!.length).toBe(50);
+  });
+
+  it("should handle error without frames", () => {
+    const event = makeEvent({
+      error: { message: "test" },
+    });
+    const result = truncateEvent(event);
+    expect(result.error!.message).toBe("test");
+    expect(result.error!.frames).toBeUndefined();
+  });
+});
+
+describe("truncateEvent - response content text truncation", () => {
+  it("should truncate text content blocks exceeding 32KB", () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          { type: "text", text: "x".repeat(40000) },
+          { type: "text", text: "short" },
+        ],
+      },
+    });
+    const result = truncateEvent(event);
+    expect(result.response.content[0].text.length).toBe(32768 + 3);
+    expect(result.response.content[0].text.endsWith("...")).toBe(true);
+    expect(result.response.content[1].text).toBe("short");
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/tests/truncation.test.ts`
+Expected: FAIL — `truncateEvent` doesn't exist yet
+
+**Step 3: Write minimal implementation**
+
+Add to `src/modules/truncation.ts`:
+
+```typescript
+// --- Field-level limit constants ---
+const MAX_USER_INTENT_LENGTH = 2_048;
+const MAX_ERROR_MESSAGE_LENGTH = 2_048;
+const MAX_RESOURCE_NAME_LENGTH = 256;
+const MAX_METADATA_LENGTH = 256;
+const MAX_STACK_FRAMES = 50;
+const MAX_CONTENT_TEXT_LENGTH = 32_768;
+
+function truncateString(
+  str: string | undefined,
+  maxLength: number,
+): string | undefined {
+  if (str == null) return str;
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength) + TRUNCATION_SUFFIX;
+}
+
+function truncateStackFrames(
+  frames: StackFrame[] | undefined,
+): StackFrame[] | undefined {
+  if (!frames || frames.length <= MAX_STACK_FRAMES) return frames;
+  const half = Math.floor(MAX_STACK_FRAMES / 2);
+  return [...frames.slice(0, half), ...frames.slice(-half)];
+}
+
+function truncateResponseContent(response: any): any {
+  if (response == null || typeof response !== "object") return response;
+  const result = { ...response };
+  if (Array.isArray(result.content)) {
+    result.content = result.content.map((block: any) => {
+      if (
+        block?.type === "text" &&
+        typeof block.text === "string" &&
+        block.text.length > MAX_CONTENT_TEXT_LENGTH
+      ) {
+        return {
+          ...block,
+          text:
+            block.text.slice(0, MAX_CONTENT_TEXT_LENGTH) + TRUNCATION_SUFFIX,
+        };
+      }
+      return block;
+    });
+  }
+  return result;
+}
+
+/**
+ * Truncates an event to guarantee it fits within MAX_EVENT_BYTES (100KB).
+ * Applies three layers:
+ * 1. Field-level string limits
+ * 2. Recursive object normalization (depth/breadth/circular-ref)
+ * 3. Size-targeted fallback (progressive depth reduction)
+ *
+ * Pure function — returns a new object, never mutates the input.
+ */
+export function truncateEvent<T extends Event | UnredactedEvent>(event: T): T {
+  // Layer 1: Field-level limits
+  const result: any = { ...event };
+
+  result.userIntent = truncateString(result.userIntent, MAX_USER_INTENT_LENGTH);
+  result.resourceName = truncateString(
+    result.resourceName,
+    MAX_RESOURCE_NAME_LENGTH,
+  );
+  result.serverName = truncateString(result.serverName, MAX_METADATA_LENGTH);
+  result.serverVersion = truncateString(
+    result.serverVersion,
+    MAX_METADATA_LENGTH,
+  );
+  result.clientName = truncateString(result.clientName, MAX_METADATA_LENGTH);
+  result.clientVersion = truncateString(
+    result.clientVersion,
+    MAX_METADATA_LENGTH,
+  );
+
+  // Error field limits
+  if (result.error != null && typeof result.error === "object") {
+    result.error = { ...result.error };
+    result.error.message = truncateString(
+      result.error.message,
+      MAX_ERROR_MESSAGE_LENGTH,
+    );
+    result.error.frames = truncateStackFrames(result.error.frames);
+  }
+
+  // Response content text limits
+  result.response = truncateResponseContent(result.response);
+
+  // Layer 2: Recursive normalization on user-controlled fields
+  if (result.parameters != null) {
+    result.parameters = normalize(result.parameters);
+  }
+  if (result.response != null) {
+    result.response = normalize(result.response);
+  }
+  if (result.identifyActorData != null) {
+    result.identifyActorData = normalize(result.identifyActorData);
+  }
+  if (result.error != null) {
+    result.error = normalize(result.error);
+  }
+
+  // Layer 3: Size-targeted normalization (Task 4)
+  return truncateToSize(result) as T;
+}
+```
+
+Note: `truncateToSize` will be a stub in this task that just returns the input, implemented properly in Task 4.
+
+Add stub:
+
+```typescript
+function truncateToSize(event: any): any {
+  return event; // Implemented in Task 4
+}
+```
+
+Also add `import { StackFrame } from "../types.js";` at the top.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/tests/truncation.test.ts`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/modules/truncation.ts src/tests/truncation.test.ts
+git commit -m "feat: add truncateEvent() with field-level limits and object normalization"
+```
+
+---
+
+### Task 4: Size-targeted normalization — truncateToSize()
+
+**Files:**
+
+- Modify: `src/modules/truncation.ts`
+- Modify: `src/tests/truncation.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add to `src/tests/truncation.test.ts`:
+
+```typescript
+describe("truncateEvent - size targeting", () => {
+  it("should leave small events unchanged", () => {
+    const event = makeEvent({
+      parameters: { query: "hello" },
+      response: { content: [{ type: "text", text: "world" }] },
+    });
+    const result = truncateEvent(event);
+    expect(JSON.stringify(result).length).toBeLessThan(102_400);
+    expect((result.parameters as any).query).toBe("hello");
+  });
+
+  it("should reduce depth progressively for events exceeding 100KB", () => {
+    // Create a deeply nested structure that's large
+    const bigNested: any = {};
+    let current = bigNested;
+    for (let i = 0; i < 8; i++) {
+      current.data = "x".repeat(15000); // 15KB per level = ~120KB total
+      current.next = {};
+      current = current.next;
+    }
+    current.data = "leaf";
+
+    const event = makeEvent({ parameters: bigNested });
+    const result = truncateEvent(event);
+
+    const size = new TextEncoder().encode(JSON.stringify(result)).length;
+    expect(size).toBeLessThanOrEqual(102_400);
+  });
+
+  it("should truncate largest string fields as last resort", () => {
+    // Create event with a single huge string that exceeds 100KB even at depth 1
+    const event = makeEvent({
+      parameters: { data: "x".repeat(120_000) },
+    });
+    const result = truncateEvent(event);
+
+    const size = new TextEncoder().encode(JSON.stringify(result)).length;
+    expect(size).toBeLessThanOrEqual(102_400);
+  });
+
+  it("should guarantee 100KB max for pathological payloads", () => {
+    // Wide + deep + large strings
+    const wide: Record<string, string> = {};
+    for (let i = 0; i < 50; i++) {
+      wide[`key${i}`] = "v".repeat(3000);
+    }
+    const event = makeEvent({
+      parameters: wide,
+      response: { data: "r".repeat(30000) },
+    });
+    const result = truncateEvent(event);
+
+    const size = new TextEncoder().encode(JSON.stringify(result)).length;
+    expect(size).toBeLessThanOrEqual(102_400);
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/tests/truncation.test.ts`
+Expected: FAIL — the size targeting tests fail because `truncateToSize` is a stub
+
+**Step 3: Write implementation**
+
+Replace the `truncateToSize` stub in `src/modules/truncation.ts`:
+
+```typescript
+/**
+ * Calculates the UTF-8 byte size of a JSON-serialized value.
+ */
+function jsonByteSize(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).length;
+}
+
+/**
+ * Finds and truncates the largest string values in an object to fit within a byte budget.
+ * Last-resort mechanism when depth reduction alone isn't enough.
+ */
+function truncateLargestFields(obj: any, maxBytes: number): any {
+  const serialized = JSON.stringify(obj);
+  const currentSize = new TextEncoder().encode(serialized).length;
+  if (currentSize <= maxBytes) return obj;
+
+  const excess = currentSize - maxBytes;
+
+  // Find all string values and their sizes, sorted largest first
+  const stringPaths: Array<{ path: string[]; length: number }> = [];
+  collectStringPaths(obj, [], stringPaths);
+  stringPaths.sort((a, b) => b.length - a.length);
+
+  // Distribute the reduction across the largest strings
+  let remaining = excess + 100; // small buffer for JSON overhead changes
+  const result = JSON.parse(JSON.stringify(obj)); // deep clone
+
+  for (const { path, length } of stringPaths) {
+    if (remaining <= 0) break;
+    const reduction = Math.min(remaining, Math.floor(length * 0.5));
+    if (reduction < 10) continue; // not worth truncating tiny strings
+    const newLength = length - reduction;
+    setNestedValue(
+      result,
+      path,
+      getNestedValue(result, path).slice(0, newLength) + TRUNCATION_SUFFIX,
+    );
+    remaining -= reduction;
+  }
+
+  return result;
+}
+
+function collectStringPaths(
+  obj: any,
+  currentPath: string[],
+  results: Array<{ path: string[]; length: number }>,
+): void {
+  if (typeof obj === "string" && obj.length > 100) {
+    results.push({ path: [...currentPath], length: obj.length });
+    return;
+  }
+  if (Array.isArray(obj)) {
+    obj.forEach((item, i) =>
+      collectStringPaths(item, [...currentPath, String(i)], results),
+    );
+    return;
+  }
+  if (obj != null && typeof obj === "object") {
+    for (const [key, value] of Object.entries(obj)) {
+      collectStringPaths(value, [...currentPath, key], results);
+    }
+  }
+}
+
+function getNestedValue(obj: any, path: string[]): any {
+  let current = obj;
+  for (const key of path) current = current[key];
+  return current;
+}
+
+function setNestedValue(obj: any, path: string[], value: any): void {
+  let current = obj;
+  for (let i = 0; i < path.length - 1; i++) current = current[path[i]];
+  current[path[path.length - 1]] = value;
+}
+
+/**
+ * Ensures an event fits within MAX_EVENT_BYTES by progressively reducing
+ * normalization depth, then truncating largest string fields as a last resort.
+ */
+function truncateToSize(event: any): any {
+  // Check if already within budget
+  if (jsonByteSize(event) <= MAX_EVENT_BYTES) return event;
+
+  // Progressive depth reduction
+  for (let depth = MAX_DEPTH - 1; depth >= 1; depth--) {
+    const reduced: any = { ...event };
+    if (reduced.parameters != null)
+      reduced.parameters = normalize(reduced.parameters, depth);
+    if (reduced.response != null)
+      reduced.response = normalize(reduced.response, depth);
+    if (reduced.identifyActorData != null)
+      reduced.identifyActorData = normalize(reduced.identifyActorData, depth);
+    if (reduced.error != null) reduced.error = normalize(reduced.error, depth);
+
+    if (jsonByteSize(reduced) <= MAX_EVENT_BYTES) return reduced;
+  }
+
+  // Last resort: truncate largest string fields
+  const minimal: any = { ...event };
+  if (minimal.parameters != null)
+    minimal.parameters = normalize(minimal.parameters, 1);
+  if (minimal.response != null)
+    minimal.response = normalize(minimal.response, 1);
+  if (minimal.identifyActorData != null)
+    minimal.identifyActorData = normalize(minimal.identifyActorData, 1);
+  if (minimal.error != null) minimal.error = normalize(minimal.error, 1);
+
+  return truncateLargestFields(minimal, MAX_EVENT_BYTES);
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/tests/truncation.test.ts`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/modules/truncation.ts src/tests/truncation.test.ts
+git commit -m "feat: add size-targeted normalization with progressive depth reduction"
+```
+
+---
+
+### Task 5: Non-mutation guarantee and edge case tests
+
+**Files:**
+
+- Modify: `src/tests/truncation.test.ts`
+
+**Step 1: Write the tests**
+
+Add to `src/tests/truncation.test.ts`:
+
+```typescript
+describe("truncateEvent - non-mutation", () => {
+  it("should not mutate the original event object", () => {
+    const longIntent = "x".repeat(3000);
+    const event = makeEvent({
+      userIntent: longIntent,
+      parameters: { deep: { nested: { data: "y".repeat(40000) } } },
+      error: {
+        message: "e".repeat(3000),
+        frames: Array.from({ length: 80 }, (_, i) => ({
+          filename: `file${i}.ts`,
+          function: `func${i}`,
+          in_app: true,
+        })),
+      },
+    });
+
+    // Deep clone for comparison
+    const originalJson = JSON.stringify(event);
+    truncateEvent(event);
+
+    expect(JSON.stringify(event)).toBe(originalJson);
+  });
+});
+
+describe("truncateEvent - edge cases", () => {
+  it("should handle empty event with minimal fields", () => {
+    const event = makeEvent({});
+    const result = truncateEvent(event);
+    expect(result.id).toBe("evt_1");
+    expect(result.sessionId).toBe("ses_1");
+  });
+
+  it("should pass through already-small events unchanged", () => {
+    const event = makeEvent({
+      userIntent: "Get weather",
+      resourceName: "fetch_weather",
+      parameters: { location: "SF" },
+      response: { content: [{ type: "text", text: "65F" }] },
+    });
+    const result = truncateEvent(event);
+    expect(result.userIntent).toBe("Get weather");
+    expect(result.resourceName).toBe("fetch_weather");
+    expect((result.parameters as any).location).toBe("SF");
+  });
+
+  it("should handle event with null parameters and response", () => {
+    const event = makeEvent({
+      parameters: null,
+      response: null,
+      error: null as any,
+    });
+    const result = truncateEvent(event);
+    expect(result.parameters).toBeNull();
+    expect(result.response).toBeNull();
+  });
+
+  it("should preserve SDK-controlled fields exactly", () => {
+    const ts = new Date("2025-01-15T12:00:00Z");
+    const event = makeEvent({
+      id: "evt_abc123",
+      sessionId: "ses_xyz789",
+      projectId: "proj_test",
+      eventType: "mcp:tools/call",
+      timestamp: ts,
+      duration: 342,
+      sdkLanguage: "typescript",
+      mcpcatVersion: "0.1.12",
+      ipAddress: "192.168.1.1",
+      isError: false,
+    });
+    const result = truncateEvent(event);
+    expect(result.id).toBe("evt_abc123");
+    expect(result.sessionId).toBe("ses_xyz789");
+    expect(result.projectId).toBe("proj_test");
+    expect(result.eventType).toBe("mcp:tools/call");
+    expect(result.timestamp).toBe(ts);
+    expect(result.duration).toBe(342);
+    expect(result.sdkLanguage).toBe("typescript");
+    expect(result.mcpcatVersion).toBe("0.1.12");
+    expect(result.ipAddress).toBe("192.168.1.1");
+    expect(result.isError).toBe(false);
+  });
+});
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/tests/truncation.test.ts`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/tests/truncation.test.ts
+git commit -m "test: add non-mutation and edge case tests for truncateEvent()"
+```
+
+---
+
+### Task 6: Integrate truncateEvent() into the event queue pipeline
+
+**Files:**
+
+- Modify: `src/modules/eventQueue.ts:67` (add truncateEvent call after sanitizeEvent)
+- Modify: `src/tests/truncation.test.ts` (add integration test)
+
+**Step 1: Write the failing integration test**
+
+Add to `src/tests/truncation.test.ts`:
+
+```typescript
+import { sanitizeEvent } from "../modules/sanitization.js";
+
+describe("truncateEvent - integration with sanitization pipeline", () => {
+  it("should work correctly after sanitizeEvent in the pipeline", () => {
+    const event = makeEvent({
+      userIntent: "x".repeat(3000),
+      parameters: {
+        imageData: "A".repeat(12000) + "=", // large base64 — sanitization will redact this
+        query: "hello",
+        nested: { deep: { value: "y".repeat(40000) } },
+      },
+      response: {
+        content: [
+          { type: "text", text: "z".repeat(40000) },
+          { type: "image", data: "base64img", mimeType: "image/png" },
+        ],
+      },
+    });
+
+    // Simulate pipeline: sanitize then truncate
+    const sanitized = sanitizeEvent(event);
+    const result = truncateEvent(sanitized);
+
+    // Sanitization should have redacted the base64 and image
+    expect((result.parameters as any).imageData).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.response.content[1]).toEqual({
+      type: "text",
+      text: "[image content redacted - not supported by MCPcat]",
+    });
+
+    // Truncation should have capped the remaining fields
+    expect(result.userIntent!.length).toBe(2048 + 3);
+    expect(result.response.content[0].text.length).toBeLessThanOrEqual(
+      32768 + 3,
+    );
+    expect((result.parameters as any).query).toBe("hello");
+  });
+});
+```
+
+**Step 2: Run test to verify it passes (truncateEvent works standalone)**
+
+Run: `pnpm vitest run src/tests/truncation.test.ts`
+Expected: PASS (this is a standalone test of the two functions composed together)
+
+**Step 3: Integrate into eventQueue.ts**
+
+In `src/modules/eventQueue.ts`, add import at the top:
+
+```typescript
+import { truncateEvent } from "./truncation.js";
+```
+
+Then after line 67 (`Object.assign(event, sanitizeEvent(event));`), add:
+
+```typescript
+Object.assign(event, truncateEvent(event));
+```
+
+So the pipeline becomes:
+
+```typescript
+      // Layer 1: Customer redaction
+      if (event.redactionFn) { ... }
+      // Layer 2: Content sanitization
+      Object.assign(event, sanitizeEvent(event));
+      // Layer 3: Event truncation
+      Object.assign(event, truncateEvent(event));
+      // Generate event ID
+      event.id = event.id || (await KSUID.withPrefix("evt").random());
+```
+
+**Step 4: Run all tests to verify nothing broke**
+
+Run: `pnpm vitest run`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/modules/eventQueue.ts src/tests/truncation.test.ts
+git commit -m "feat: integrate truncateEvent() into event queue pipeline after sanitization"
+```
+
+---
+
+### Task 7: Final verification — lint, typecheck, full test suite
+
+**Files:**
+
+- No new files
+
+**Step 1: Run linter**
+
+Run: `pnpm run lint`
+Expected: No errors (fix any lint issues found)
+
+**Step 2: Run typecheck**
+
+Run: `pnpm run typecheck`
+Expected: No type errors
+
+**Step 3: Run full test suite**
+
+Run: `pnpm vitest run`
+Expected: All tests PASS
+
+**Step 4: Commit any lint/type fixes**
+
+```bash
+git add -A
+git commit -m "chore: fix lint and type issues in truncation module"
+```
+
+(Skip if no fixes needed)

--- a/src/modules/eventQueue.ts
+++ b/src/modules/eventQueue.ts
@@ -10,6 +10,7 @@ import { getServerTrackingData } from "./internal.js";
 import { getSessionInfo } from "./session.js";
 import { redactEvent } from "./redaction.js";
 import { sanitizeEvent } from "./sanitization.js";
+import { truncateEvent } from "./truncation.js";
 import KSUID from "../thirdparty/ksuid/index.js";
 import { getMCPCompatibleErrorMessage } from "./compatibility.js";
 import { TelemetryManager } from "./telemetry.js";
@@ -65,6 +66,7 @@ class EventQueue {
       }
 
       Object.assign(event, sanitizeEvent(event));
+      Object.assign(event, truncateEvent(event));
 
       event.id = event.id || (await KSUID.withPrefix("evt").random());
       this.activeRequests++;

--- a/src/modules/eventQueue.ts
+++ b/src/modules/eventQueue.ts
@@ -9,6 +9,7 @@ import { writeToLog } from "./logging.js";
 import { getServerTrackingData } from "./internal.js";
 import { getSessionInfo } from "./session.js";
 import { redactEvent } from "./redaction.js";
+import { sanitizeEvent } from "./sanitization.js";
 import KSUID from "../thirdparty/ksuid/index.js";
 import { getMCPCompatibleErrorMessage } from "./compatibility.js";
 import { TelemetryManager } from "./telemetry.js";
@@ -50,27 +51,27 @@ class EventQueue {
 
     while (this.queue.length > 0 && this.activeRequests < this.concurrency) {
       const event = this.queue.shift();
-      if (event?.redactionFn) {
-        // Redact sensitive information if a redaction function is provided
+      if (!event) continue;
+
+      if (event.redactionFn) {
         try {
           const redactedEvent = await redactEvent(event, event.redactionFn);
-          event.redactionFn = undefined; // Clear the function to avoid reprocessing
+          event.redactionFn = undefined;
           Object.assign(event, redactedEvent);
         } catch (error) {
           writeToLog(`Failed to redact event: ${error}`);
-          continue; // Skip this event if redaction fails
+          continue;
         }
       }
 
-      if (event) {
-        event.id = event.id || (await KSUID.withPrefix("evt").random());
-        this.activeRequests++;
-        this.sendEvent(event as Event).finally(() => {
-          this.activeRequests--;
-          // Try to process more events
-          this.process();
-        });
-      }
+      Object.assign(event, sanitizeEvent(event));
+
+      event.id = event.id || (await KSUID.withPrefix("evt").random());
+      this.activeRequests++;
+      this.sendEvent(event as Event).finally(() => {
+        this.activeRequests--;
+        this.process();
+      });
     }
 
     this.processing = false;

--- a/src/modules/sanitization.ts
+++ b/src/modules/sanitization.ts
@@ -1,0 +1,138 @@
+import { Event, UnredactedEvent } from "../types.js";
+
+const BASE64_PATTERN = /^[A-Za-z0-9+/\n\r]+=*$/;
+const SIZE_GATE = 10240; // 10KB - skip strings shorter than this
+
+/**
+ * Sanitizes an event by redacting non-text content blocks from responses
+ * and large base64-encoded strings from parameters.
+ *
+ * This is a synchronous operation that returns a new object without mutating the original.
+ * It should run after customer redaction in the event pipeline.
+ */
+export function sanitizeEvent<T extends Event | UnredactedEvent>(event: T): T {
+  const result = { ...event };
+
+  if (result.response != null) {
+    result.response = sanitizeResponse(result.response);
+  }
+
+  if (result.parameters != null) {
+    result.parameters = sanitizeParameters(result.parameters);
+  }
+
+  return result;
+}
+
+/**
+ * Sanitizes response content blocks by replacing non-text content types
+ * with informative redaction messages.
+ */
+function sanitizeResponse(response: any): any {
+  if (response == null || typeof response !== "object") {
+    return response;
+  }
+
+  const result = { ...response };
+
+  if (Array.isArray(result.content)) {
+    result.content = result.content.map(sanitizeContentBlock);
+  }
+
+  if (
+    result.structuredContent != null &&
+    typeof result.structuredContent === "object"
+  ) {
+    result.structuredContent = sanitizeParameters(result.structuredContent);
+  }
+
+  return result;
+}
+
+/**
+ * Sanitizes a single content block based on its type discriminator.
+ */
+function sanitizeContentBlock(block: any): any {
+  if (block == null || typeof block !== "object") {
+    return block;
+  }
+
+  switch (block.type) {
+    case "text":
+      return block;
+
+    case "image":
+      return {
+        type: "text",
+        text: "[image content redacted - not supported by MCPcat]",
+      };
+
+    case "audio":
+      return {
+        type: "text",
+        text: "[audio content redacted - not supported by MCPcat]",
+      };
+
+    case "resource":
+      return sanitizeResourceBlock(block);
+
+    case "resource_link":
+      return block;
+
+    default:
+      return {
+        type: "text",
+        text: `[unsupported content type "${block.type}" redacted - not supported by MCPcat]`,
+      };
+  }
+}
+
+/**
+ * Sanitizes an embedded resource content block.
+ * BlobResourceContents (has `blob` field) are redacted.
+ * TextResourceContents (has `text` field) pass through.
+ */
+function sanitizeResourceBlock(block: any): any {
+  if (block.resource && block.resource.blob !== undefined) {
+    return {
+      type: "text",
+      text: "[binary resource content redacted - not supported by MCPcat]",
+    };
+  }
+  return block;
+}
+
+/**
+ * Recursively scans parameters for large base64-encoded strings and replaces them.
+ * Uses a size gate (10KB) to avoid regex testing on small strings.
+ */
+function sanitizeParameters(obj: any): any {
+  if (obj == null) {
+    return obj;
+  }
+
+  if (typeof obj === "string") {
+    if (obj.length >= SIZE_GATE && BASE64_PATTERN.test(obj)) {
+      return "[binary data redacted - not supported by MCPcat]";
+    }
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeParameters);
+  }
+
+  if (obj instanceof Date) {
+    return obj;
+  }
+
+  if (typeof obj === "object") {
+    const result: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = sanitizeParameters(value);
+    }
+    return result;
+  }
+
+  return obj;
+}

--- a/src/modules/truncation.ts
+++ b/src/modules/truncation.ts
@@ -1,0 +1,406 @@
+import { Event, UnredactedEvent, StackFrame } from "../types.js";
+
+// --- Constants ---
+export const MAX_DEPTH = 10;
+export const MAX_BREADTH = 100;
+export const MAX_STRING_LENGTH = 32_768; // 32KB
+export const MAX_EVENT_BYTES = 102_400; // 100KB
+
+// --- Field-level limit constants ---
+const MAX_USER_INTENT_LENGTH = 2_048;
+const MAX_ERROR_MESSAGE_LENGTH = 2_048;
+const MAX_RESOURCE_NAME_LENGTH = 256;
+const MAX_METADATA_LENGTH = 256;
+const MAX_STACK_FRAMES = 50;
+const MAX_CONTENT_TEXT_LENGTH = 32_768;
+
+// --- Truncation markers ---
+const TRUNCATION_SUFFIX = "...";
+
+/**
+ * Recursively normalizes a value, handling:
+ * - String truncation (> MAX_STRING_LENGTH)
+ * - Non-serializable values (functions, symbols, undefined, BigInt, NaN, Infinity)
+ * - Date objects -> ISO string
+ * - Circular reference detection
+ * - Depth limiting
+ * - Breadth limiting
+ */
+export function normalize(
+  input: unknown,
+  depth: number = MAX_DEPTH,
+  maxBreadth: number = MAX_BREADTH,
+  maxStringLength: number = MAX_STRING_LENGTH,
+): unknown {
+  const memo = new WeakSet<object>();
+  return visit(input, depth, maxBreadth, maxStringLength, memo);
+}
+
+function visit(
+  value: unknown,
+  remainingDepth: number,
+  maxBreadth: number,
+  maxStringLength: number,
+  memo: WeakSet<object>,
+): unknown {
+  // null
+  if (value === null) return null;
+
+  // undefined
+  if (value === undefined) return "[undefined]";
+
+  // boolean
+  if (typeof value === "boolean") return value;
+
+  // number (including NaN, Infinity)
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) return "[NaN]";
+    if (!Number.isFinite(value))
+      return value > 0 ? "[Infinity]" : "[-Infinity]";
+    return value;
+  }
+
+  // bigint
+  if (typeof value === "bigint") return `[BigInt: ${value}]`;
+
+  // string
+  if (typeof value === "string") {
+    if (value.length > maxStringLength) {
+      return value.slice(0, maxStringLength) + TRUNCATION_SUFFIX;
+    }
+    return value;
+  }
+
+  // symbol
+  if (typeof value === "symbol") {
+    const desc = value.description;
+    return desc ? `[Symbol(${desc})]` : "[Symbol()]";
+  }
+
+  // function
+  if (typeof value === "function") {
+    const name = value.name || "<anonymous>";
+    return `[Function: ${name}]`;
+  }
+
+  // Date
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime())
+      ? "[Invalid Date]"
+      : value.toISOString();
+  }
+
+  // Objects and arrays from here — need depth/breadth/circular checks
+  if (typeof value === "object") {
+    // Circular reference detection
+    if (memo.has(value)) return "[Circular ~]";
+
+    // Depth limit
+    if (remainingDepth <= 0) {
+      return Array.isArray(value) ? "[Array]" : "[Object]";
+    }
+
+    memo.add(value);
+
+    let result: unknown;
+    if (Array.isArray(value)) {
+      result = visitArray(
+        value,
+        remainingDepth - 1,
+        maxBreadth,
+        maxStringLength,
+        memo,
+      );
+    } else {
+      result = visitObject(
+        value as Record<string, unknown>,
+        remainingDepth - 1,
+        maxBreadth,
+        maxStringLength,
+        memo,
+      );
+    }
+
+    memo.delete(value);
+    return result;
+  }
+
+  // Fallback: coerce to string
+  return String(value);
+}
+
+function visitArray(
+  arr: unknown[],
+  remainingDepth: number,
+  maxBreadth: number,
+  maxStringLength: number,
+  memo: WeakSet<object>,
+): unknown[] {
+  const result: unknown[] = [];
+  for (let i = 0; i < arr.length; i++) {
+    if (i >= maxBreadth) {
+      result.push("[MaxProperties ~]");
+      break;
+    }
+    result.push(
+      visit(arr[i], remainingDepth, maxBreadth, maxStringLength, memo),
+    );
+  }
+  return result;
+}
+
+function visitObject(
+  obj: Record<string, unknown>,
+  remainingDepth: number,
+  maxBreadth: number,
+  maxStringLength: number,
+  memo: WeakSet<object>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const keys = Object.keys(obj);
+  let count = 0;
+
+  for (const key of keys) {
+    if (count >= maxBreadth) {
+      result["..."] = "[MaxProperties ~]";
+      break;
+    }
+    // Skip undefined values — matches JSON.stringify behavior (omits undefined properties)
+    if (obj[key] === undefined) continue;
+    result[key] = visit(
+      obj[key],
+      remainingDepth,
+      maxBreadth,
+      maxStringLength,
+      memo,
+    );
+    count++;
+  }
+
+  return result;
+}
+
+// --- Field-level truncation helpers ---
+
+function truncateString(
+  str: string | undefined,
+  maxLength: number,
+): string | undefined {
+  if (str == null) return str;
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength) + TRUNCATION_SUFFIX;
+}
+
+function truncateStackFrames(
+  frames: StackFrame[] | undefined,
+): StackFrame[] | undefined {
+  if (!frames || frames.length <= MAX_STACK_FRAMES) return frames;
+  const half = Math.floor(MAX_STACK_FRAMES / 2);
+  return [...frames.slice(0, half), ...frames.slice(-half)];
+}
+
+function truncateResponseContent(response: any): any {
+  if (response == null || typeof response !== "object") return response;
+  const result = { ...response };
+  if (Array.isArray(result.content)) {
+    result.content = result.content.map((block: any) => {
+      if (
+        block?.type === "text" &&
+        typeof block.text === "string" &&
+        block.text.length > MAX_CONTENT_TEXT_LENGTH
+      ) {
+        return {
+          ...block,
+          text:
+            block.text.slice(0, MAX_CONTENT_TEXT_LENGTH) + TRUNCATION_SUFFIX,
+        };
+      }
+      return block;
+    });
+  }
+  return result;
+}
+
+/**
+ * Calculates the UTF-8 byte size of a JSON-serialized value.
+ */
+const textEncoder = new TextEncoder();
+
+function jsonByteSize(value: unknown): number {
+  return textEncoder.encode(JSON.stringify(value)).length;
+}
+
+/**
+ * Finds and truncates the largest string values in an object to fit within a byte budget.
+ * Last-resort mechanism when depth reduction alone isn't enough.
+ * Iterates until the result fits or no further reduction is possible.
+ */
+function truncateLargestFields(obj: any, maxBytes: number): any {
+  let result = JSON.parse(JSON.stringify(obj)); // deep clone
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const currentSize = jsonByteSize(result);
+    if (currentSize <= maxBytes) return result;
+
+    const excess = currentSize - maxBytes;
+
+    // Find all string values and their sizes, sorted largest first
+    const stringPaths: Array<{ path: string[]; length: number }> = [];
+    collectStringPaths(result, [], stringPaths);
+    stringPaths.sort((a, b) => b.length - a.length);
+
+    if (stringPaths.length === 0) break; // no strings left to truncate
+
+    // Distribute the reduction across the largest strings
+    let remaining = excess + 200; // buffer for JSON overhead from added "..." suffixes
+    let truncated = false;
+
+    for (const { path, length } of stringPaths) {
+      if (remaining <= 0) break;
+      const reduction = Math.min(remaining, Math.floor(length * 0.5));
+      if (reduction < 10) continue; // not worth truncating tiny strings
+      const newLength = length - reduction;
+      setNestedValue(
+        result,
+        path,
+        getNestedValue(result, path).slice(0, newLength) + TRUNCATION_SUFFIX,
+      );
+      remaining -= reduction;
+      truncated = true;
+    }
+
+    if (!truncated) break; // no progress possible
+  }
+
+  return result;
+}
+
+function collectStringPaths(
+  obj: any,
+  currentPath: string[],
+  results: Array<{ path: string[]; length: number }>,
+): void {
+  if (typeof obj === "string" && obj.length > 100) {
+    results.push({ path: [...currentPath], length: obj.length });
+    return;
+  }
+  if (Array.isArray(obj)) {
+    obj.forEach((item, i) =>
+      collectStringPaths(item, [...currentPath, String(i)], results),
+    );
+    return;
+  }
+  if (obj != null && typeof obj === "object") {
+    for (const [key, value] of Object.entries(obj)) {
+      collectStringPaths(value, [...currentPath, key], results);
+    }
+  }
+}
+
+function getNestedValue(obj: any, path: string[]): any {
+  let current = obj;
+  for (const key of path) current = current[key];
+  return current;
+}
+
+function setNestedValue(obj: any, path: string[], value: any): void {
+  let current = obj;
+  for (let i = 0; i < path.length - 1; i++) current = current[path[i]];
+  current[path[path.length - 1]] = value;
+}
+
+/**
+ * Ensures an event fits within MAX_EVENT_BYTES by progressively reducing
+ * normalization depth, then truncating largest string fields as a last resort.
+ */
+function truncateToSize(event: any): any {
+  // Check if already within budget
+  if (jsonByteSize(event) <= MAX_EVENT_BYTES) return event;
+
+  // Progressive depth reduction
+  for (let depth = MAX_DEPTH - 1; depth >= 1; depth--) {
+    const reduced: any = { ...event };
+    if (reduced.parameters != null)
+      reduced.parameters = normalize(reduced.parameters, depth);
+    if (reduced.response != null)
+      reduced.response = normalize(reduced.response, depth);
+    if (reduced.identifyActorData != null)
+      reduced.identifyActorData = normalize(reduced.identifyActorData, depth);
+    if (reduced.error != null) reduced.error = normalize(reduced.error, depth);
+
+    if (jsonByteSize(reduced) <= MAX_EVENT_BYTES) return reduced;
+  }
+
+  // Last resort: truncate largest string fields
+  const minimal: any = { ...event };
+  if (minimal.parameters != null)
+    minimal.parameters = normalize(minimal.parameters, 1);
+  if (minimal.response != null)
+    minimal.response = normalize(minimal.response, 1);
+  if (minimal.identifyActorData != null)
+    minimal.identifyActorData = normalize(minimal.identifyActorData, 1);
+  if (minimal.error != null) minimal.error = normalize(minimal.error, 1);
+
+  return truncateLargestFields(minimal, MAX_EVENT_BYTES);
+}
+
+/**
+ * Applies layered truncation to an event:
+ * 1. Field-level string limits (userIntent, resourceName, metadata fields, error.message)
+ * 2. Error frame limiting (first 25 + last 25 if > 50)
+ * 3. Response content text limits (32KB per text block)
+ * 4. Recursive normalization on user-controlled fields
+ * 5. Size-targeted truncation (progressive depth reduction + last-resort string truncation)
+ */
+export function truncateEvent<T extends Event | UnredactedEvent>(event: T): T {
+  const result: any = { ...event };
+
+  // Layer 1: Field-level string limits
+  result.userIntent = truncateString(result.userIntent, MAX_USER_INTENT_LENGTH);
+  result.resourceName = truncateString(
+    result.resourceName,
+    MAX_RESOURCE_NAME_LENGTH,
+  );
+  result.serverName = truncateString(result.serverName, MAX_METADATA_LENGTH);
+  result.serverVersion = truncateString(
+    result.serverVersion,
+    MAX_METADATA_LENGTH,
+  );
+  result.clientName = truncateString(result.clientName, MAX_METADATA_LENGTH);
+  result.clientVersion = truncateString(
+    result.clientVersion,
+    MAX_METADATA_LENGTH,
+  );
+
+  // Error field limits
+  if (result.error != null && typeof result.error === "object") {
+    result.error = { ...result.error };
+    result.error.message = truncateString(
+      result.error.message,
+      MAX_ERROR_MESSAGE_LENGTH,
+    );
+    if (result.error.frames !== undefined) {
+      result.error.frames = truncateStackFrames(result.error.frames);
+    }
+  }
+
+  // Response content text limits
+  result.response = truncateResponseContent(result.response);
+
+  // Layer 2: Recursive normalization on user-controlled fields
+  if (result.parameters != null) {
+    result.parameters = normalize(result.parameters);
+  }
+  if (result.response != null) {
+    result.response = normalize(result.response);
+  }
+  if (result.identifyActorData != null) {
+    result.identifyActorData = normalize(result.identifyActorData);
+  }
+  if (result.error != null) {
+    result.error = normalize(result.error);
+  }
+
+  // Layer 3: Size-targeted normalization
+  return truncateToSize(result) as T;
+}

--- a/src/tests/sanitization.test.ts
+++ b/src/tests/sanitization.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeEvent } from "../modules/sanitization.js";
+import { Event } from "../types.js";
+
+function makeLargeBase64(sizeInChars = 12000): string {
+  return "A".repeat(sizeInChars - 1) + "=";
+}
+
+function makeLargeNonBase64(sizeInChars = 12000): string {
+  return "Hello, world! This is NOT base64. ".repeat(
+    Math.ceil(sizeInChars / 34),
+  );
+}
+
+function makeEvent(overrides: Partial<Event>): Event {
+  return {
+    id: "evt_1",
+    sessionId: "ses_1",
+    eventType: "mcp:tools/call",
+    timestamp: new Date(),
+    ...overrides,
+  } as Event;
+}
+
+describe("sanitizeEvent - response content blocks", () => {
+  it("should replace image and audio blocks but keep text blocks", () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          { type: "text", text: "Hello world" },
+          { type: "image", data: "base64imagedata...", mimeType: "image/png" },
+          { type: "audio", data: "base64audiodata...", mimeType: "audio/wav" },
+        ],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content).toHaveLength(3);
+    expect(result.response.content[0]).toEqual({
+      type: "text",
+      text: "Hello world",
+    });
+    expect(result.response.content[1]).toEqual({
+      type: "text",
+      text: "[image content redacted - not supported by MCPcat]",
+    });
+    expect(result.response.content[2]).toEqual({
+      type: "text",
+      text: "[audio content redacted - not supported by MCPcat]",
+    });
+  });
+
+  it("should leave text-only content unchanged", () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          { type: "text", text: "First" },
+          { type: "text", text: "Second" },
+        ],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content).toEqual([
+      { type: "text", text: "First" },
+      { type: "text", text: "Second" },
+    ]);
+  });
+
+  it("should redact EmbeddedResource with blob", () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          {
+            type: "resource",
+            resource: {
+              uri: "file:///data.bin",
+              blob: "base64blobdata...",
+              mimeType: "application/octet-stream",
+            },
+          },
+        ],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content[0]).toEqual({
+      type: "text",
+      text: "[binary resource content redacted - not supported by MCPcat]",
+    });
+  });
+
+  it("should pass through EmbeddedResource with text", () => {
+    const textResource = {
+      type: "resource",
+      resource: {
+        uri: "file:///readme.txt",
+        text: "This is a text resource",
+        mimeType: "text/plain",
+      },
+    };
+
+    const event = makeEvent({
+      response: { content: [textResource] },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content[0]).toEqual(textResource);
+  });
+
+  it("should redact unknown content types with type name in message", () => {
+    const event = makeEvent({
+      response: {
+        content: [{ type: "video", data: "somestuff", mimeType: "video/mp4" }],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content[0]).toEqual({
+      type: "text",
+      text: '[unsupported content type "video" redacted - not supported by MCPcat]',
+    });
+  });
+
+  it("should pass through resource_link unchanged", () => {
+    const resourceLink = {
+      type: "resource_link",
+      uri: "file:///some/resource",
+      name: "My Resource",
+    };
+
+    const event = makeEvent({
+      response: { content: [resourceLink] },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.content[0]).toEqual(resourceLink);
+  });
+
+  it("should redact large base64 inside structuredContent", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      response: {
+        structuredContent: {
+          data: largeBase64,
+          label: "some label",
+        },
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response.structuredContent.data).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.response.structuredContent.label).toBe("some label");
+  });
+
+  it("should handle response without content array", () => {
+    const event = makeEvent({
+      response: { result: "success" },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.response).toEqual({ result: "success" });
+  });
+
+  it("should handle null and undefined response without error", () => {
+    const resultNull = sanitizeEvent(makeEvent({ response: null }));
+    const resultUndef = sanitizeEvent(makeEvent({ response: undefined }));
+
+    expect(resultNull.response).toBeNull();
+    expect(resultUndef.response).toBeUndefined();
+  });
+});
+
+describe("sanitizeEvent - parameter scanning", () => {
+  it("should leave small strings unchanged", () => {
+    const event = makeEvent({
+      parameters: {
+        name: "hello",
+        query: "some query text",
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters).toEqual({
+      name: "hello",
+      query: "some query text",
+    });
+  });
+
+  it("should redact large base64 strings (>10KB)", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      parameters: { imageData: largeBase64 },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.imageData).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+  });
+
+  it("should leave large non-base64 strings unchanged", () => {
+    const largeText = makeLargeNonBase64();
+
+    const event = makeEvent({
+      parameters: { longText: largeText },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.longText).toBe(largeText);
+  });
+
+  it("should find and redact deeply nested large base64", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      parameters: {
+        level1: {
+          level2: {
+            level3: { data: largeBase64 },
+          },
+        },
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.level1.level2.level3.data).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+  });
+
+  it("should only redact large base64 in mixed-type parameters", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      parameters: {
+        count: 42,
+        active: true,
+        name: "short string",
+        binaryData: largeBase64,
+        tags: ["a", "b", "c"],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.count).toBe(42);
+    expect(result.parameters.active).toBe(true);
+    expect(result.parameters.name).toBe("short string");
+    expect(result.parameters.binaryData).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.parameters.tags).toEqual(["a", "b", "c"]);
+  });
+
+  it("should redact large base64 inside an array", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      parameters: {
+        items: ["small string", largeBase64, "another small"],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.items[0]).toBe("small string");
+    expect(result.parameters.items[1]).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.parameters.items[2]).toBe("another small");
+  });
+
+  it("should redact base64 string at exactly SIZE_GATE boundary (10240 chars)", () => {
+    const exactBoundary = makeLargeBase64(10240);
+    const belowBoundary = makeLargeBase64(10239);
+
+    const event = makeEvent({
+      parameters: {
+        atGate: exactBoundary,
+        belowGate: belowBoundary,
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.atGate).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.parameters.belowGate).toBe(belowBoundary);
+  });
+
+  it("should handle null and undefined parameters without error", () => {
+    const resultNull = sanitizeEvent(makeEvent({ parameters: null }));
+    const resultUndef = sanitizeEvent(makeEvent({ parameters: undefined }));
+
+    expect(resultNull.parameters).toBeNull();
+    expect(resultUndef.parameters).toBeUndefined();
+  });
+});
+
+describe("sanitizeEvent - integration", () => {
+  it("should sanitize both parameters and response in a full event", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      projectId: "proj_1",
+      resourceName: "my-tool",
+      parameters: {
+        imageData: largeBase64,
+        query: "hello",
+      },
+      response: {
+        content: [
+          { type: "text", text: "Result text" },
+          { type: "image", data: "base64img", mimeType: "image/png" },
+        ],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    expect(result.parameters.imageData).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.parameters.query).toBe("hello");
+
+    expect(result.response.content[0]).toEqual({
+      type: "text",
+      text: "Result text",
+    });
+    expect(result.response.content[1]).toEqual({
+      type: "text",
+      text: "[image content redacted - not supported by MCPcat]",
+    });
+
+    expect(result.id).toBe("evt_1");
+    expect(result.sessionId).toBe("ses_1");
+    expect(result.projectId).toBe("proj_1");
+    expect(result.resourceName).toBe("my-tool");
+  });
+
+  it("should not mutate the original event", () => {
+    const largeBase64 = makeLargeBase64();
+
+    const event = makeEvent({
+      parameters: { imageData: largeBase64 },
+      response: {
+        content: [{ type: "image", data: "base64img", mimeType: "image/png" }],
+      },
+    });
+
+    const result = sanitizeEvent(event);
+
+    // Original should be unchanged
+    expect(event.parameters.imageData).toBe(largeBase64);
+    expect(event.response.content[0].type).toBe("image");
+    expect(event.response.content[0].data).toBe("base64img");
+
+    // Result should be different
+    expect(result.parameters.imageData).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.response.content[0].type).toBe("text");
+  });
+});

--- a/src/tests/truncation.test.ts
+++ b/src/tests/truncation.test.ts
@@ -1,0 +1,504 @@
+import { describe, it, expect } from "vitest";
+import { normalize, truncateEvent } from "../modules/truncation.js";
+import { sanitizeEvent } from "../modules/sanitization.js";
+import { Event, StackFrame } from "../types.js";
+
+describe("normalize - string truncation", () => {
+  it("should leave short strings unchanged", () => {
+    expect(normalize("hello")).toBe("hello");
+  });
+
+  it("should truncate strings exceeding maxStringLength with '...'", () => {
+    const long = "a".repeat(33000);
+    const result = normalize(long) as string;
+    expect(result.length).toBe(32768 + 3); // 32KB + "..."
+    expect(result.endsWith("...")).toBe(true);
+    expect(result.startsWith("a".repeat(100))).toBe(true);
+  });
+
+  it("should leave strings at exactly maxStringLength unchanged", () => {
+    const exact = "a".repeat(32768);
+    expect(normalize(exact)).toBe(exact);
+  });
+});
+
+describe("normalize - non-serializable values", () => {
+  it("should convert functions to descriptive string", () => {
+    function myFunc() {}
+    expect(normalize(myFunc)).toBe("[Function: myFunc]");
+  });
+
+  it("should convert anonymous functions", () => {
+    expect(normalize(() => {})).toBe("[Function: <anonymous>]");
+  });
+
+  it("should convert symbols", () => {
+    expect(normalize(Symbol("test"))).toBe("[Symbol(test)]");
+    expect(normalize(Symbol())).toBe("[Symbol()]");
+  });
+
+  it("should convert undefined to string marker", () => {
+    expect(normalize(undefined)).toBe("[undefined]");
+  });
+
+  it("should convert BigInt to string marker", () => {
+    expect(normalize(BigInt(123))).toBe("[BigInt: 123]");
+  });
+
+  it("should convert NaN to string marker", () => {
+    expect(normalize(NaN)).toBe("[NaN]");
+  });
+
+  it("should convert Infinity to string marker", () => {
+    expect(normalize(Infinity)).toBe("[Infinity]");
+    expect(normalize(-Infinity)).toBe("[-Infinity]");
+  });
+
+  it("should convert Date to ISO string", () => {
+    const date = new Date("2025-01-15T12:00:00Z");
+    expect(normalize(date)).toBe("2025-01-15T12:00:00.000Z");
+  });
+
+  it("should handle Invalid Date gracefully", () => {
+    expect(normalize(new Date("not-a-date"))).toBe("[Invalid Date]");
+  });
+
+  it("should pass through numbers unchanged", () => {
+    expect(normalize(42)).toBe(42);
+    expect(normalize(0)).toBe(0);
+    expect(normalize(-3.14)).toBe(-3.14);
+  });
+
+  it("should pass through booleans unchanged", () => {
+    expect(normalize(true)).toBe(true);
+    expect(normalize(false)).toBe(false);
+  });
+
+  it("should pass through null as null", () => {
+    expect(normalize(null)).toBeNull();
+  });
+});
+
+describe("normalize - depth limiting", () => {
+  it("should collapse objects beyond max depth to '[Object]'", () => {
+    let obj: any = { value: "deep" };
+    for (let i = 0; i < 15; i++) {
+      obj = { nested: obj };
+    }
+    const result = normalize(obj, 5) as any;
+    expect(result.nested.nested.nested.nested.nested).toBe("[Object]");
+  });
+
+  it("should collapse arrays beyond max depth to '[Array]'", () => {
+    let arr: any = ["leaf"];
+    for (let i = 0; i < 15; i++) {
+      arr = [arr];
+    }
+    const result = normalize(arr, 3) as any;
+    expect(result[0][0][0]).toBe("[Array]");
+  });
+
+  it("should handle depth=0 by collapsing top-level objects", () => {
+    expect(normalize({ a: 1 }, 0)).toBe("[Object]");
+    expect(normalize([1, 2], 0)).toBe("[Array]");
+  });
+
+  it("should not collapse primitives regardless of depth", () => {
+    expect(normalize("hello", 0)).toBe("hello");
+    expect(normalize(42, 0)).toBe(42);
+  });
+});
+
+describe("normalize - breadth limiting", () => {
+  it("should limit object properties to maxBreadth", () => {
+    const wide: Record<string, number> = {};
+    for (let i = 0; i < 150; i++) {
+      wide[`key${i}`] = i;
+    }
+    const result = normalize(wide, 10, 5) as Record<string, unknown>;
+    const keys = Object.keys(result);
+    expect(keys.length).toBe(6); // 5 real keys + 1 sentinel key
+    expect(result["..."]).toBe("[MaxProperties ~]");
+  });
+
+  it("should limit array elements to maxBreadth", () => {
+    const wide = Array.from({ length: 150 }, (_, i) => i);
+    const result = normalize(wide, 10, 5) as unknown[];
+    expect(result.length).toBe(6); // 5 real elements + 1 sentinel
+    expect(result[5]).toBe("[MaxProperties ~]");
+  });
+
+  it("should leave objects within breadth limit unchanged", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = normalize(obj, 10, 100) as Record<string, unknown>;
+    expect(result).toEqual({ a: 1, b: 2, c: 3 });
+  });
+});
+
+describe("normalize - circular reference detection", () => {
+  it("should detect circular object references", () => {
+    const obj: any = { a: 1 };
+    obj.self = obj;
+    const result = normalize(obj) as any;
+    expect(result.a).toBe(1);
+    expect(result.self).toBe("[Circular ~]");
+  });
+
+  it("should detect circular array references", () => {
+    const arr: any[] = [1, 2];
+    arr.push(arr);
+    const result = normalize(arr) as any;
+    expect(result[0]).toBe(1);
+    expect(result[1]).toBe(2);
+    expect(result[2]).toBe("[Circular ~]");
+  });
+
+  it("should allow same object in different branches (not a cycle)", () => {
+    const shared = { value: "shared" };
+    const obj = { a: shared, b: shared };
+    const result = normalize(obj) as any;
+    expect(result.a).toEqual({ value: "shared" });
+    expect(result.b).toEqual({ value: "shared" });
+  });
+
+  it("should detect deeply nested circular references", () => {
+    const obj: any = { level1: { level2: { level3: {} } } };
+    obj.level1.level2.level3.backToRoot = obj;
+    const result = normalize(obj) as any;
+    expect(result.level1.level2.level3.backToRoot).toBe("[Circular ~]");
+  });
+});
+
+describe("normalize - undefined property handling", () => {
+  it("should omit undefined object properties (matching JSON.stringify behavior)", () => {
+    const obj = { a: 1, b: undefined, c: "hello" };
+    const result = normalize(obj) as Record<string, unknown>;
+    expect(result).toEqual({ a: 1, c: "hello" });
+    expect("b" in result).toBe(false);
+  });
+
+  it("should still convert top-level undefined to marker", () => {
+    expect(normalize(undefined)).toBe("[undefined]");
+  });
+});
+
+// --- truncateEvent tests ---
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: "evt_1",
+    sessionId: "ses_1",
+    eventType: "mcp:tools/call",
+    timestamp: new Date("2025-01-15T12:00:00Z"),
+    ...overrides,
+  } as Event;
+}
+
+describe("truncateEvent - field-level string limits", () => {
+  it("should truncate userIntent exceeding 2048 chars", () => {
+    const event = makeEvent({ userIntent: "x".repeat(3000) });
+    const result = truncateEvent(event);
+    expect(result.userIntent!.length).toBe(2048 + 3);
+    expect(result.userIntent!.endsWith("...")).toBe(true);
+  });
+
+  it("should truncate resourceName exceeding 256 chars", () => {
+    const event = makeEvent({ resourceName: "t".repeat(300) });
+    const result = truncateEvent(event);
+    expect(result.resourceName!.length).toBe(256 + 3);
+    expect(result.resourceName!.endsWith("...")).toBe(true);
+  });
+
+  it("should truncate serverName, serverVersion, clientName, clientVersion exceeding 256 chars", () => {
+    const event = makeEvent({
+      serverName: "s".repeat(300),
+      serverVersion: "v".repeat(300),
+      clientName: "c".repeat(300),
+      clientVersion: "cv".repeat(200),
+    });
+    const result = truncateEvent(event);
+    expect(result.serverName!.length).toBe(256 + 3);
+    expect(result.serverVersion!.length).toBe(256 + 3);
+    expect(result.clientName!.length).toBe(256 + 3);
+    expect(result.clientVersion!.length).toBe(256 + 3);
+  });
+
+  it("should leave short field values unchanged", () => {
+    const event = makeEvent({
+      userIntent: "Get weather",
+      resourceName: "fetch_weather",
+      serverName: "my-server",
+    });
+    const result = truncateEvent(event);
+    expect(result.userIntent).toBe("Get weather");
+    expect(result.resourceName).toBe("fetch_weather");
+    expect(result.serverName).toBe("my-server");
+  });
+
+  it("should handle undefined/null fields gracefully", () => {
+    const event = makeEvent({
+      userIntent: undefined,
+      resourceName: undefined,
+      serverName: undefined,
+    });
+    const result = truncateEvent(event);
+    expect(result.userIntent).toBeUndefined();
+    expect(result.resourceName).toBeUndefined();
+    expect(result.serverName).toBeUndefined();
+  });
+});
+
+describe("truncateEvent - error field limits", () => {
+  it("should truncate error.message exceeding 2048 chars", () => {
+    const event = makeEvent({
+      error: {
+        message: "e".repeat(3000),
+        type: "Error",
+      },
+    });
+    const result = truncateEvent(event);
+    expect(result.error!.message.length).toBe(2048 + 3);
+    expect(result.error!.message.endsWith("...")).toBe(true);
+  });
+
+  it("should limit error.frames to 50 (first 25 + last 25)", () => {
+    const frames: StackFrame[] = Array.from({ length: 80 }, (_, i) => ({
+      filename: `file${i}.ts`,
+      function: `func${i}`,
+      lineno: i + 1,
+      in_app: true,
+    }));
+    const event = makeEvent({
+      error: { message: "test", frames },
+    });
+    const result = truncateEvent(event);
+    expect(result.error!.frames!.length).toBe(50);
+    // First 25 should be from the start
+    expect(result.error!.frames![0].filename).toBe("file0.ts");
+    expect(result.error!.frames![24].filename).toBe("file24.ts");
+    // Last 25 should be from the end
+    expect(result.error!.frames![25].filename).toBe("file55.ts");
+    expect(result.error!.frames![49].filename).toBe("file79.ts");
+  });
+
+  it("should leave frames at exactly 50 unchanged", () => {
+    const frames: StackFrame[] = Array.from({ length: 50 }, (_, i) => ({
+      filename: `file${i}.ts`,
+      function: `func${i}`,
+      in_app: true,
+    }));
+    const event = makeEvent({
+      error: { message: "test", frames },
+    });
+    const result = truncateEvent(event);
+    expect(result.error!.frames!.length).toBe(50);
+  });
+
+  it("should handle error without frames", () => {
+    const event = makeEvent({
+      error: { message: "test" },
+    });
+    const result = truncateEvent(event);
+    expect(result.error!.message).toBe("test");
+    expect(result.error!.frames).toBeUndefined();
+  });
+});
+
+describe("truncateEvent - response content text truncation", () => {
+  it("should truncate text content blocks exceeding 32KB", () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          { type: "text", text: "x".repeat(40000) },
+          { type: "text", text: "short" },
+        ],
+      },
+    });
+    const result = truncateEvent(event);
+    expect(result.response.content[0].text.length).toBe(32768 + 3);
+    expect(result.response.content[0].text.endsWith("...")).toBe(true);
+    expect(result.response.content[1].text).toBe("short");
+  });
+});
+
+describe("truncateEvent - size targeting", () => {
+  it("should leave small events unchanged", () => {
+    const event = makeEvent({
+      parameters: { query: "hello" },
+      response: { content: [{ type: "text", text: "world" }] },
+    });
+    const result = truncateEvent(event);
+    expect(
+      new TextEncoder().encode(JSON.stringify(result)).length,
+    ).toBeLessThan(102_400);
+    expect((result.parameters as any).query).toBe("hello");
+  });
+
+  it("should reduce depth progressively for events exceeding 100KB", () => {
+    // Create a deeply nested structure that's large
+    const bigNested: any = {};
+    let current = bigNested;
+    for (let i = 0; i < 8; i++) {
+      current.data = "x".repeat(15000); // 15KB per level = ~120KB total
+      current.next = {};
+      current = current.next;
+    }
+    current.data = "leaf";
+
+    const event = makeEvent({ parameters: bigNested });
+    const result = truncateEvent(event);
+
+    const size = new TextEncoder().encode(JSON.stringify(result)).length;
+    expect(size).toBeLessThanOrEqual(102_400);
+  });
+
+  it("should truncate largest string fields as last resort", () => {
+    // Create event with a single huge string that exceeds 100KB even at depth 1
+    const event = makeEvent({
+      parameters: { data: "x".repeat(120_000) },
+    });
+    const result = truncateEvent(event);
+
+    const size = new TextEncoder().encode(JSON.stringify(result)).length;
+    expect(size).toBeLessThanOrEqual(102_400);
+  });
+
+  it("should guarantee 100KB max for pathological payloads", () => {
+    // Wide + deep + large strings
+    const wide: Record<string, string> = {};
+    for (let i = 0; i < 50; i++) {
+      wide[`key${i}`] = "v".repeat(3000);
+    }
+    const event = makeEvent({
+      parameters: wide,
+      response: { data: "r".repeat(30000) },
+    });
+    const result = truncateEvent(event);
+
+    const size = new TextEncoder().encode(JSON.stringify(result)).length;
+    expect(size).toBeLessThanOrEqual(102_400);
+  });
+});
+
+describe("truncateEvent - non-mutation", () => {
+  it("should not mutate the original event object", () => {
+    const longIntent = "x".repeat(3000);
+    const event = makeEvent({
+      userIntent: longIntent,
+      parameters: { deep: { nested: { data: "y".repeat(40000) } } },
+      error: {
+        message: "e".repeat(3000),
+        frames: Array.from({ length: 80 }, (_, i) => ({
+          filename: `file${i}.ts`,
+          function: `func${i}`,
+          in_app: true,
+        })),
+      },
+    });
+
+    // Deep clone for comparison
+    const originalJson = JSON.stringify(event);
+    truncateEvent(event);
+
+    expect(JSON.stringify(event)).toBe(originalJson);
+  });
+});
+
+describe("truncateEvent - edge cases", () => {
+  it("should handle empty event with minimal fields", () => {
+    const event = makeEvent({});
+    const result = truncateEvent(event);
+    expect(result.id).toBe("evt_1");
+    expect(result.sessionId).toBe("ses_1");
+  });
+
+  it("should pass through already-small events unchanged", () => {
+    const event = makeEvent({
+      userIntent: "Get weather",
+      resourceName: "fetch_weather",
+      parameters: { location: "SF" },
+      response: { content: [{ type: "text", text: "65F" }] },
+    });
+    const result = truncateEvent(event);
+    expect(result.userIntent).toBe("Get weather");
+    expect(result.resourceName).toBe("fetch_weather");
+    expect((result.parameters as any).location).toBe("SF");
+  });
+
+  it("should handle event with null parameters and response", () => {
+    const event = makeEvent({
+      parameters: null,
+      response: null,
+      error: null as any,
+    });
+    const result = truncateEvent(event);
+    expect(result.parameters).toBeNull();
+    expect(result.response).toBeNull();
+  });
+
+  it("should preserve SDK-controlled fields exactly", () => {
+    const ts = new Date("2025-01-15T12:00:00Z");
+    const event = makeEvent({
+      id: "evt_abc123",
+      sessionId: "ses_xyz789",
+      projectId: "proj_test",
+      eventType: "mcp:tools/call",
+      timestamp: ts,
+      duration: 342,
+      sdkLanguage: "typescript",
+      mcpcatVersion: "0.1.12",
+      ipAddress: "192.168.1.1",
+      isError: false,
+    });
+    const result = truncateEvent(event);
+    expect(result.id).toBe("evt_abc123");
+    expect(result.sessionId).toBe("ses_xyz789");
+    expect(result.projectId).toBe("proj_test");
+    expect(result.eventType).toBe("mcp:tools/call");
+    expect(result.timestamp).toBe(ts);
+    expect(result.duration).toBe(342);
+    expect(result.sdkLanguage).toBe("typescript");
+    expect(result.mcpcatVersion).toBe("0.1.12");
+    expect(result.ipAddress).toBe("192.168.1.1");
+    expect(result.isError).toBe(false);
+  });
+});
+
+describe("truncateEvent - integration with sanitization pipeline", () => {
+  it("should work correctly after sanitizeEvent in the pipeline", () => {
+    const event = makeEvent({
+      userIntent: "x".repeat(3000),
+      parameters: {
+        imageData: "A".repeat(12000) + "=", // large base64 — sanitization will redact this
+        query: "hello",
+        nested: { deep: { value: "y".repeat(40000) } },
+      },
+      response: {
+        content: [
+          { type: "text", text: "z".repeat(40000) },
+          { type: "image", data: "base64img", mimeType: "image/png" },
+        ],
+      },
+    });
+
+    // Simulate pipeline: sanitize then truncate
+    const sanitized = sanitizeEvent(event);
+    const result = truncateEvent(sanitized);
+
+    // Sanitization should have redacted the base64 and image
+    expect((result.parameters as any).imageData).toBe(
+      "[binary data redacted - not supported by MCPcat]",
+    );
+    expect(result.response.content[1]).toEqual({
+      type: "text",
+      text: "[image content redacted - not supported by MCPcat]",
+    });
+
+    // Truncation should have capped the remaining fields
+    expect(result.userIntent!.length).toBe(2048 + 3);
+    expect(result.response.content[0].text.length).toBeLessThanOrEqual(
+      32768 + 3,
+    );
+    expect((result.parameters as any).query).toBe("hello");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a three-layer event truncation system (`src/modules/truncation.ts`) that guarantees no event exceeds 100KB before being sent to the MCPCat API
- **Layer 1:** Field-level limits (userIntent 2K, resourceName 256, metadata 256, error.message 2K, stack frames 50, response text 32KB)
- **Layer 2:** Recursive object normalization (depth 10, breadth 100, circular ref detection, non-serializable value coercion)
- **Layer 3:** Size-targeted fallback with progressive depth reduction and last-resort string truncation
- Integrates into the event queue pipeline after `sanitizeEvent()` — 2 lines added to `eventQueue.ts`
- 48 new tests covering all truncation behaviors, edge cases, non-mutation guarantees, and the 100KB size constraint

> **Depends on:** #25 (content sanitization) — this branch is based on `feat/content-sanitization`

## Test plan

- [x] All 48 truncation tests pass
- [x] Full test suite passes (369/369 + 1 pre-existing skip)
- [x] Lint clean
- [x] Typecheck clean
- [ ] Verify events are truncated in staging with oversized tool responses