### PR TITLE
fix: respect enableTracing flag when publishing events

### DIFF
--- a/src/modules/eventQueue.ts
+++ b/src/modules/eventQueue.ts
@@ -231,6 +231,10 @@ export function publishEvent(
     return;
   }
 
+  if (!data.options.enableTracing) {
+    return;
+  }
+
   const sessionInfo = getSessionInfo(server, data);
 
   // Calculate duration if not provided

--- a/src/tests/eventQueue.test.ts
+++ b/src/tests/eventQueue.test.ts
@@ -51,7 +51,7 @@ describe("EventQueue", () => {
     (getServerTrackingData as any).mockReturnValue({
       projectId: "test-project",
       sessionId: "test-session",
-      options: {},
+      options: { enableTracing: true },
     });
 
     // Mock session info
@@ -108,6 +108,26 @@ describe("EventQueue", () => {
       expect(writeToLog).toHaveBeenCalledWith(
         "Warning: Server tracking data not found. Event will not be published.",
       );
+    });
+
+    it("should not publish event when enableTracing is false", () => {
+      (getServerTrackingData as any).mockReturnValue({
+        projectId: "test-project",
+        sessionId: "test-session",
+        options: { enableTracing: false },
+      });
+
+      const mockServer: MCPServerLike = {} as any;
+      const event: Event = {
+        sessionId: "test-session",
+        tool: "test-tool",
+        timestamp: new Date(),
+        arguments: { test: "value" },
+      };
+
+      publishEvent(mockServer, event);
+
+      expect(getSessionInfo).not.toHaveBeenCalled();
     });
 
     it("should calculate duration when not provided", () => {


### PR DESCRIPTION
When enableTracing is set to false, no events should be published to MCPCat or telemetry exporters. Added a centralized check in publishEvent() that gates event publishing for all call sites. Added test coverage to verify the flag prevents event publishing.