### PR TITLE
feat: add apiBaseUrl option for custom API endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { eventQueue } from "./modules/eventQueue.js";
  * @param options.customContextDescription - Custom description for the injected context parameter. Only applies when enableToolCallContext is true. Use this to provide domain-specific guidance to LLMs about what context they should provide.
  * @param options.identify - Async function to identify users and attach custom data to their sessions.
  * @param options.redactSensitiveInformation - Function to redact sensitive data before sending to MCPCat.
+ * @param options.apiBaseUrl - Custom API base URL for sending events. Falls back to the `MCPCAT_API_URL` environment variable if not set, then to the default `https://api.mcpcat.io`.
  * @param options.exporters - Configure telemetry exporters to send events to external systems. Available exporters:
  *   - `otlp`: OpenTelemetry Protocol exporter (see {@link ../modules/exporters/otlp.OTLPExporter})
  *   - `datadog`: Datadog APM exporter (see {@link ../modules/exporters/datadog.DatadogExporter})
@@ -142,6 +143,12 @@ function track(
 ): any {
   try {
     const validatedServer = isCompatibleServerType(server);
+
+    // Resolve API base URL: option > env var > default
+    const apiBaseUrl = options.apiBaseUrl || process.env.MCPCAT_API_URL;
+    if (apiBaseUrl) {
+      eventQueue.configure(apiBaseUrl);
+    }
 
     // For high-level servers, we need to pass the underlying server to some functions
     const lowLevelServer = (

--- a/src/modules/eventQueue.ts
+++ b/src/modules/eventQueue.ts
@@ -30,6 +30,11 @@ class EventQueue {
     this.apiClient = new EventsApi(config);
   }
 
+  configure(apiBaseUrl: string): void {
+    const config = new Configuration({ basePath: apiBaseUrl });
+    this.apiClient = new EventsApi(config);
+  }
+
   setTelemetryManager(telemetryManager: TelemetryManager): void {
     this.telemetryManager = telemetryManager;
   }

--- a/src/tests/api-base-url.test.ts
+++ b/src/tests/api-base-url.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MCPCatOptions } from "../types.js";
+import { setupTestHooks } from "./test-utils.js";
+
+describe("MCPCatOptions apiBaseUrl", () => {
+  it("should accept apiBaseUrl as an optional string property", () => {
+    const options: MCPCatOptions = {
+      apiBaseUrl: "https://custom.example.com",
+    };
+    expect(options.apiBaseUrl).toBe("https://custom.example.com");
+  });
+
+  it("should be undefined when not set", () => {
+    const options: MCPCatOptions = {};
+    expect(options.apiBaseUrl).toBeUndefined();
+  });
+});
+
+// Mock external dependencies (same pattern as eventQueue.test.ts)
+vi.mock("mcpcat-api");
+vi.mock("../modules/logging.js");
+vi.mock("../thirdparty/ksuid/index.js");
+
+// Import mocked modules
+import { Configuration, EventsApi } from "mcpcat-api";
+
+// Import the module under test after mocking
+const { eventQueue } = await import("../modules/eventQueue.js");
+
+describe("EventQueue.configure()", () => {
+  setupTestHooks();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Setup mock implementations as regular functions (not arrow functions) so `new` works
+    (Configuration as any).mockImplementation(function () {
+      return {};
+    });
+    (EventsApi as any).mockImplementation(function () {
+      return { publishEvent: vi.fn().mockResolvedValue({}) };
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should reconfigure the apiClient with the given base URL", () => {
+    // Clear the constructor call from EventQueue's constructor
+    (Configuration as any).mockClear();
+
+    eventQueue.configure("https://custom.example.com");
+
+    expect(Configuration).toHaveBeenCalledWith({
+      basePath: "https://custom.example.com",
+    });
+  });
+});
+
+// Additional mocks needed for track() tests
+vi.mock("../modules/compatibility.js");
+vi.mock("../modules/session.js");
+vi.mock("../modules/internal.js");
+vi.mock("../modules/tools.js");
+vi.mock("../modules/tracing.js");
+vi.mock("../modules/tracingV2.js");
+vi.mock("../modules/telemetry.js");
+
+import {
+  isCompatibleServerType,
+  isHighLevelServer,
+} from "../modules/compatibility.js";
+import { getSessionInfo, newSessionId } from "../modules/session.js";
+import {
+  setServerTrackingData,
+  getServerTrackingData,
+} from "../modules/internal.js";
+
+// Import track after all mocks
+const { track } = await import("../index.js");
+
+describe("track() URL resolution", () => {
+  setupTestHooks();
+
+  const savedEnv = process.env.MCPCAT_API_URL;
+
+  // Create a mock server object that passes isCompatibleServerType
+  const mockServer = {
+    _requestHandlers: new Map(),
+    _serverInfo: { name: "test-server", version: "1.0.0" },
+    getClientVersion: () => undefined,
+    setRequestHandler: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.MCPCAT_API_URL;
+
+    // Setup mock implementations as regular functions so `new` works
+    (Configuration as any).mockImplementation(function () {
+      return {};
+    });
+    (EventsApi as any).mockImplementation(function () {
+      return { publishEvent: vi.fn().mockResolvedValue({}) };
+    });
+
+    // Setup compatibility mocks: return the server as-is (low-level server)
+    (isCompatibleServerType as any).mockReturnValue(mockServer);
+    (isHighLevelServer as any).mockReturnValue(false);
+
+    // Setup session/internal mocks
+    (getSessionInfo as any).mockReturnValue({});
+    (newSessionId as any).mockReturnValue("ses_test123");
+    (getServerTrackingData as any).mockReturnValue(null); // Not yet tracked
+    (setServerTrackingData as any).mockImplementation(() => {});
+
+    // Spy on eventQueue.configure
+    vi.spyOn(eventQueue, "configure");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // Restore env var
+    if (savedEnv !== undefined) {
+      process.env.MCPCAT_API_URL = savedEnv;
+    } else {
+      delete process.env.MCPCAT_API_URL;
+    }
+  });
+
+  it("should call configure() when apiBaseUrl option is provided", () => {
+    track(mockServer, "proj_test123", {
+      apiBaseUrl: "https://custom-api.example.com",
+    });
+
+    expect(eventQueue.configure).toHaveBeenCalledWith(
+      "https://custom-api.example.com",
+    );
+  });
+
+  it("should call configure() with MCPCAT_API_URL env var when no option is set", () => {
+    process.env.MCPCAT_API_URL = "https://env-api.example.com";
+
+    track(mockServer, "proj_test123", {});
+
+    expect(eventQueue.configure).toHaveBeenCalledWith(
+      "https://env-api.example.com",
+    );
+  });
+
+  it("should prioritize apiBaseUrl option over MCPCAT_API_URL env var", () => {
+    process.env.MCPCAT_API_URL = "https://env-api.example.com";
+
+    track(mockServer, "proj_test123", {
+      apiBaseUrl: "https://option-api.example.com",
+    });
+
+    expect(eventQueue.configure).toHaveBeenCalledWith(
+      "https://option-api.example.com",
+    );
+    expect(eventQueue.configure).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not call configure() when neither option nor env var is set", () => {
+    delete process.env.MCPCAT_API_URL;
+
+    track(mockServer, "proj_test123", {});
+
+    expect(eventQueue.configure).not.toHaveBeenCalled();
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface MCPCatOptions {
   ) => Promise<UserIdentity | null>;
   redactSensitiveInformation?: RedactFunction;
   exporters?: Record<string, ExporterConfig>;
+  apiBaseUrl?: string;
 }
 
 export type ToolCallback =


### PR DESCRIPTION
## Summary
- Adds `apiBaseUrl` to `MCPCatOptions` so customers can point event publishing at a custom API endpoint
- Resolution priority: `apiBaseUrl` option > `MCPCAT_API_URL` env var > default (`https://api.mcpcat.io`)
- Previously available to beta customers, now being published to the public SDK

## Changes
- `MCPCatOptions` interface gets a new optional `apiBaseUrl?: string` field
- `EventQueue` gets a `configure()` method that reconfigures the API client with a new base path
- `track()` resolves the URL at initialization time and calls `configure()` only when a non-default URL is provided
- JSDoc updated to document the env var fallback behavior

## Test plan
- [ ] `pnpm test -- --run src/tests/api-base-url.test.ts` — 7 new tests covering all resolution paths
- [ ] `pnpm test` — full suite passes (385 tests)
- [ ] Verify default behavior is unchanged when neither option nor env var is set