### PR TITLE
fix: clean up OTLP exporter config and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@modelcontextprotocol/sdk": ">=1.11"
   },
   "dependencies": {
-    "@opentelemetry/otlp-transformer": "^0.203.0",
     "mcpcat-api": "0.1.7"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ overrides:
 importers:
   .:
     dependencies:
-      "@opentelemetry/otlp-transformer":
-        specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.0)
       mcpcat-api:
         specifier: 0.1.7
         version: 0.1.7
@@ -664,80 +661,12 @@ packages:
       }
     engines: { node: ">= 8" }
 
-  "@opentelemetry/api-logs@0.203.0":
-    resolution:
-      {
-        integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==,
-      }
-    engines: { node: ">=8.0.0" }
-
   "@opentelemetry/api@1.9.0":
     resolution:
       {
         integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==,
       }
     engines: { node: ">=8.0.0" }
-
-  "@opentelemetry/core@2.0.1":
-    resolution:
-      {
-        integrity: sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ">=1.0.0 <1.10.0"
-
-  "@opentelemetry/otlp-transformer@0.203.0":
-    resolution:
-      {
-        integrity: sha512-Y8I6GgoCna0qDQ2W6GCRtaF24SnvqvA8OfeTi7fqigD23u8Jpb4R5KFv/pRvrlGagcCLICMIyh9wiejp4TXu/A==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ^1.3.0
-
-  "@opentelemetry/resources@2.0.1":
-    resolution:
-      {
-        integrity: sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ">=1.3.0 <1.10.0"
-
-  "@opentelemetry/sdk-logs@0.203.0":
-    resolution:
-      {
-        integrity: sha512-vM2+rPq0Vi3nYA5akQD2f3QwossDnTDLvKbea6u/A2NZ3XDkPxMfo/PNrDoXhDUD/0pPo2CdH5ce/thn9K0kLw==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ">=1.4.0 <1.10.0"
-
-  "@opentelemetry/sdk-metrics@2.0.1":
-    resolution:
-      {
-        integrity: sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ">=1.9.0 <1.10.0"
-
-  "@opentelemetry/sdk-trace-base@2.0.1":
-    resolution:
-      {
-        integrity: sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ">=1.3.0 <1.10.0"
-
-  "@opentelemetry/semantic-conventions@1.36.0":
-    resolution:
-      {
-        integrity: sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==,
-      }
-    engines: { node: ">=14" }
 
   "@pkgjs/parseargs@0.11.0":
     resolution:
@@ -750,66 +679,6 @@ packages:
     resolution:
       {
         integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==,
-      }
-
-  "@protobufjs/aspromise@1.1.2":
-    resolution:
-      {
-        integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==,
-      }
-
-  "@protobufjs/base64@1.1.2":
-    resolution:
-      {
-        integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==,
-      }
-
-  "@protobufjs/codegen@2.0.4":
-    resolution:
-      {
-        integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==,
-      }
-
-  "@protobufjs/eventemitter@1.1.0":
-    resolution:
-      {
-        integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==,
-      }
-
-  "@protobufjs/fetch@1.1.0":
-    resolution:
-      {
-        integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==,
-      }
-
-  "@protobufjs/float@1.0.2":
-    resolution:
-      {
-        integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==,
-      }
-
-  "@protobufjs/inquire@1.1.0":
-    resolution:
-      {
-        integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==,
-      }
-
-  "@protobufjs/path@1.1.2":
-    resolution:
-      {
-        integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==,
-      }
-
-  "@protobufjs/pool@1.1.0":
-    resolution:
-      {
-        integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==,
-      }
-
-  "@protobufjs/utf8@1.1.0":
-    resolution:
-      {
-        integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==,
       }
 
   "@rollup/rollup-android-arm-eabi@4.41.1":
@@ -2566,12 +2435,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  long@5.3.2:
-    resolution:
-      {
-        integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==,
-      }
-
   lru-cache@10.4.3:
     resolution:
       {
@@ -3026,13 +2889,6 @@ packages:
       }
     engines: { node: ">=14" }
     hasBin: true
-
-  protobufjs@7.5.3:
-    resolution:
-      {
-        integrity: sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==,
-      }
-    engines: { node: ">=12.0.0" }
 
   proxy-addr@2.0.7:
     resolution:
@@ -4142,83 +3998,13 @@ snapshots:
       "@nodelib/fs.scandir": 2.1.5
       fastq: 1.19.1
 
-  "@opentelemetry/api-logs@0.203.0":
-    dependencies:
-      "@opentelemetry/api": 1.9.0
-
-  "@opentelemetry/api@1.9.0": {}
-
-  "@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0)":
-    dependencies:
-      "@opentelemetry/api": 1.9.0
-      "@opentelemetry/semantic-conventions": 1.36.0
-
-  "@opentelemetry/otlp-transformer@0.203.0(@opentelemetry/api@1.9.0)":
-    dependencies:
-      "@opentelemetry/api": 1.9.0
-      "@opentelemetry/api-logs": 0.203.0
-      "@opentelemetry/core": 2.0.1(@opentelemetry/api@1.9.0)
-      "@opentelemetry/resources": 2.0.1(@opentelemetry/api@1.9.0)
-      "@opentelemetry/sdk-logs": 0.203.0(@opentelemetry/api@1.9.0)
-      "@opentelemetry/sdk-metrics": 2.0.1(@opentelemetry/api@1.9.0)
-      "@opentelemetry/sdk-trace-base": 2.0.1(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.3
-
-  "@opentelemetry/resources@2.0.1(@opentelemetry/api@1.9.0)":
-    dependencies:
-      "@opentelemetry/api": 1.9.0
-      "@opentelemetry/core": 2.0.1(@opentelemetry/api@1.9.0)
-      "@opentelemetry/semantic-conventions": 1.36.0
-
-  "@opentelemetry/sdk-logs@0.203.0(@opentelemetry/api@1.9.0)":
-    dependencies:
-      "@opentelemetry/api": 1.9.0
-      "@opentelemetry/api-logs": 0.203.0
-      "@opentelemetry/core": 2.0.1(@opentelemetry/api@1.9.0)
-      "@opentelemetry/resources": 2.0.1(@opentelemetry/api@1.9.0)
-
-  "@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.0)":
-    dependencies:
-      "@opentelemetry/api": 1.9.0
-      "@opentelemetry/core": 2.0.1(@opentelemetry/api@1.9.0)
-      "@opentelemetry/resources": 2.0.1(@opentelemetry/api@1.9.0)
-
-  "@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0)":
-    dependencies:
-      "@opentelemetry/api": 1.9.0
-      "@opentelemetry/core": 2.0.1(@opentelemetry/api@1.9.0)
-      "@opentelemetry/resources": 2.0.1(@opentelemetry/api@1.9.0)
-      "@opentelemetry/semantic-conventions": 1.36.0
-
-  "@opentelemetry/semantic-conventions@1.36.0": {}
+  "@opentelemetry/api@1.9.0":
+    optional: true
 
   "@pkgjs/parseargs@0.11.0":
     optional: true
 
   "@polka/url@1.0.0-next.29": {}
-
-  "@protobufjs/aspromise@1.1.2": {}
-
-  "@protobufjs/base64@1.1.2": {}
-
-  "@protobufjs/codegen@2.0.4": {}
-
-  "@protobufjs/eventemitter@1.1.0": {}
-
-  "@protobufjs/fetch@1.1.0":
-    dependencies:
-      "@protobufjs/aspromise": 1.1.2
-      "@protobufjs/inquire": 1.1.0
-
-  "@protobufjs/float@1.0.2": {}
-
-  "@protobufjs/inquire@1.1.0": {}
-
-  "@protobufjs/path@1.1.2": {}
-
-  "@protobufjs/pool@1.1.0": {}
-
-  "@protobufjs/utf8@1.1.0": {}
 
   "@rollup/rollup-android-arm-eabi@4.41.1":
     optional: true
@@ -5220,8 +5006,6 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
 
-  long@5.3.2: {}
-
   lru-cache@10.4.3: {}
 
   magic-string@0.30.17:
@@ -5422,21 +5206,6 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.5.3: {}
-
-  protobufjs@7.5.3:
-    dependencies:
-      "@protobufjs/aspromise": 1.1.2
-      "@protobufjs/base64": 1.1.2
-      "@protobufjs/codegen": 2.0.4
-      "@protobufjs/eventemitter": 1.1.0
-      "@protobufjs/fetch": 1.1.0
-      "@protobufjs/float": 1.0.2
-      "@protobufjs/inquire": 1.1.0
-      "@protobufjs/path": 1.1.2
-      "@protobufjs/pool": 1.1.0
-      "@protobufjs/utf8": 1.1.0
-      "@types/node": 22.15.21
-      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:

--- a/src/modules/exporters/otlp.ts
+++ b/src/modules/exporters/otlp.ts
@@ -5,20 +5,18 @@ import { traceContext } from "./trace-context.js";
 export interface OTLPExporterConfig {
   type: "otlp";
   endpoint: string;
-  protocol?: "http/protobuf" | "grpc";
   headers?: Record<string, string>;
-  compression?: "gzip" | "none";
 }
 
 export class OTLPExporter implements Exporter {
   private endpoint: string;
   private headers: Record<string, string>;
-  private protocol: string;
 
   constructor(config: OTLPExporterConfig) {
-    // Default to HTTP protocol on localhost
-    this.protocol = config.protocol || "http/protobuf";
-    this.endpoint = config.endpoint;
+    // Auto-append /v1/traces per OTLP spec if not already present
+    const url = config.endpoint.replace(/\/+$/, "");
+    this.endpoint = url.endsWith("/v1/traces") ? url : `${url}/v1/traces`;
+
     this.headers = {
       "Content-Type": "application/json", // Using JSON for now for easier debugging
       ...config.headers,


### PR DESCRIPTION
## Summary

- Auto-append `/v1/traces` to the OTLP endpoint per spec
- Remove unused `@opentelemetry/otlp-transformer` production dependency (was never imported)
- Remove non-functional `protocol` and `compression` config options from `OTLPExporterConfig` (code always sends JSON; these silently did nothing)

## Test

- `pnpm test` — all 379 tests pass
- `pnpm typecheck` — clean
- Verify `new OTLPExporter({ type: "otlp", endpoint: "http://localhost:4318" })` resolves to `http://localhost:4318/v1/traces`
- Verify `new OTLPExporter({ type: "otlp", endpoint: "http://localhost:4318/v1/traces" })` is unchanged