### PR TITLE
feat(posthog): UUIDv7 session IDs and flat event properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcpcat",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Analytics tool for MCP (Model Context Protocol) servers - tracks tool usage patterns and provides insights",
   "type": "module",
   "main": "dist/index.js",
@@ -56,6 +56,7 @@
     "@changesets/cli": "^2.29.8",
     "@modelcontextprotocol/sdk": "~1.24.2",
     "@types/node": "^22.15.21",
+    "@types/uuid": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
     "@vitest/coverage-v8": "^4.0.14",
@@ -66,6 +67,7 @@
     "prettier": "^3.5.3",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
+    "uuid": "^13.0.0",
     "vitest": "^4.0.14",
     "zod": "^3.25 || ^4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       "@types/node":
         specifier: ^22.15.21
         version: 22.15.21
+      "@types/uuid":
+        specifier: ^11.0.0
+        version: 11.0.0
       "@typescript-eslint/eslint-plugin":
         specifier: ^8.32.1
         version: 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.39.1)(typescript@5.8.3))(eslint@9.39.1)(typescript@5.8.3)
@@ -57,6 +60,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.0
       vitest:
         specifier: ^4.0.14
         version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@22.15.21)(@vitest/ui@4.0.14)(yaml@2.8.0)
@@ -1064,6 +1070,13 @@ packages:
       {
         integrity: sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==,
       }
+
+  "@types/uuid@11.0.0":
+    resolution:
+      {
+        integrity: sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==,
+      }
+    deprecated: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
 
   "@typescript-eslint/eslint-plugin@8.32.1":
     resolution:
@@ -3432,6 +3445,13 @@ packages:
         integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
       }
 
+  uuid@13.0.0:
+    resolution:
+      {
+        integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==,
+      }
+    hasBin: true
+
   vary@1.1.2:
     resolution:
       {
@@ -4152,6 +4172,10 @@ snapshots:
   "@types/node@22.15.21":
     dependencies:
       undici-types: 6.21.0
+
+  "@types/uuid@11.0.0":
+    dependencies:
+      uuid: 13.0.0
 
   "@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.39.1)(typescript@5.8.3))(eslint@9.39.1)(typescript@5.8.3)":
     dependencies:
@@ -5572,6 +5596,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uuid@13.0.0: {}
 
   vary@1.1.2: {}
 

--- a/src/modules/exporters/posthog.ts
+++ b/src/modules/exporters/posthog.ts
@@ -5,18 +5,6 @@ import { PublishEventRequestEventTypeEnum } from "mcpcat-api";
 import { MCPCAT_SOURCE } from "../constants.js";
 import KSUID from "../../thirdparty/ksuid/index.js";
 
-function toUUID(id: string): string {
-  const hash = createHash("sha256").update(id).digest("hex");
-  return [
-    hash.substring(0, 8),
-    hash.substring(8, 12),
-    "5" + hash.substring(13, 16),
-    ((parseInt(hash[16], 16) & 0x3) | 0x8).toString(16) +
-      hash.substring(17, 20),
-    hash.substring(20, 32),
-  ].join("-");
-}
-
 /**
  * Generates a deterministic UUIDv7 from a prefixed KSUID (e.g. ses_xxx).
  * Uses the KSUID's embedded timestamp for the UUIDv7 timestamp portion
@@ -278,8 +266,8 @@ export class PostHogExporter implements Exporter {
 
     const properties: Record<string, any> = {
       $ai_session_id: `mcpcat_${event.sessionId}`,
-      $ai_trace_id: toUUID(event.sessionId),
-      $ai_span_id: toUUID(event.id),
+      $ai_trace_id: toUUIDv7(event.sessionId),
+      $ai_span_id: toUUIDv7(event.id),
       $ai_span_name: event.resourceName || "unknown_tool",
       $ai_is_error: event.isError || false,
       $session_id: toUUIDv7(event.sessionId),

--- a/src/modules/exporters/posthog.ts
+++ b/src/modules/exporters/posthog.ts
@@ -3,6 +3,7 @@ import { Event, Exporter } from "../../types.js";
 import { writeToLog } from "../logging.js";
 import { PublishEventRequestEventTypeEnum } from "mcpcat-api";
 import { MCPCAT_SOURCE } from "../constants.js";
+import KSUID from "../../thirdparty/ksuid/index.js";
 
 function toUUID(id: string): string {
   const hash = createHash("sha256").update(id).digest("hex");
@@ -13,6 +14,57 @@ function toUUID(id: string): string {
     ((parseInt(hash[16], 16) & 0x3) | 0x8).toString(16) +
       hash.substring(17, 20),
     hash.substring(20, 32),
+  ].join("-");
+}
+
+/**
+ * Generates a deterministic UUIDv7 from a prefixed KSUID (e.g. ses_xxx).
+ * Uses the KSUID's embedded timestamp for the UUIDv7 timestamp portion
+ * and a SHA-256 hash of the full ID for the random bits.
+ */
+export function toUUIDv7(prefixedId: string): string {
+  // Strip prefix (ses_, evt_, etc.) and parse KSUID
+  const ksuidStr = prefixedId.replace(/^[a-z]+_/, "");
+  let timestampMs: number;
+  try {
+    const ksuid = KSUID.parse(ksuidStr);
+    timestampMs = ksuid.date.getTime();
+  } catch {
+    // Fallback: if KSUID parsing fails, use current time
+    timestampMs = Date.now();
+  }
+
+  // Hash the full ID for deterministic random bits
+  const hash = createHash("sha256").update(prefixedId).digest();
+
+  const buf = Buffer.alloc(16);
+
+  // Bytes 0-5: 48-bit Unix timestamp in milliseconds
+  buf.writeUIntBE(timestampMs, 0, 6);
+
+  // Byte 6: version 7 (0111) + high 4 bits of rand_a from hash
+  buf[6] = 0x70 | (hash[0] & 0x0f);
+  // Byte 7: low 8 bits of rand_a from hash
+  buf[7] = hash[1];
+
+  // Byte 8: variant 10 + high 6 bits of rand_b from hash
+  buf[8] = 0x80 | (hash[2] & 0x3f);
+  // Bytes 9-15: remaining rand_b from hash
+  buf[9] = hash[3];
+  buf[10] = hash[4];
+  buf[11] = hash[5];
+  buf[12] = hash[6];
+  buf[13] = hash[7];
+  buf[14] = hash[8];
+  buf[15] = hash[9];
+
+  const hex = buf.toString("hex");
+  return [
+    hex.substring(0, 8),
+    hex.substring(8, 12),
+    hex.substring(12, 16),
+    hex.substring(16, 20),
+    hex.substring(20, 32),
   ].join("-");
 }
 
@@ -117,7 +169,7 @@ export class PostHogExporter implements Exporter {
     const timestamp = getTimestamp(event);
 
     const properties: Record<string, any> = {
-      $session_id: event.sessionId,
+      $session_id: toUUIDv7(event.sessionId),
       source: MCPCAT_SOURCE,
     };
 
@@ -184,7 +236,7 @@ export class PostHogExporter implements Exporter {
 
     const properties: Record<string, any> = {
       $exception_source: "backend",
-      $session_id: event.sessionId,
+      $session_id: toUUIDv7(event.sessionId),
     };
 
     if (event.error) {
@@ -230,7 +282,7 @@ export class PostHogExporter implements Exporter {
       $ai_span_id: toUUID(event.id),
       $ai_span_name: event.resourceName || "unknown_tool",
       $ai_is_error: event.isError || false,
-      $session_id: event.sessionId,
+      $session_id: toUUIDv7(event.sessionId),
       source: MCPCAT_SOURCE,
     };
 

--- a/src/tests/posthog-exporter.test.ts
+++ b/src/tests/posthog-exporter.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { PostHogExporter } from "../modules/exporters/posthog.js";
 import { Event } from "../types.js";
 import { PublishEventRequestEventTypeEnum } from "mcpcat-api";
+import { validate as uuidValidate, version as uuidVersion } from "uuid";
+
+function expectUUIDv7(value: string) {
+  expect(uuidValidate(value)).toBe(true);
+  expect(uuidVersion(value)).toBe(7);
+}
 
 describe("PostHogExporter", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -64,7 +70,7 @@ describe("PostHogExporter", () => {
     expect(event.timestamp).toBe("2025-01-15T10:00:00.000Z");
 
     // Verify properties
-    expect(event.properties.$session_id).toBe("ses_session456");
+    expectUUIDv7(event.properties.$session_id);
     expect(event.properties.tool_name).toBe("get_weather");
     expect(event.properties.resource_name).toBe("get_weather");
     expect(event.properties.duration_ms).toBe(150);
@@ -165,7 +171,7 @@ describe("PostHogExporter", () => {
       "TimeoutError: Connection timeout\n    at fetch (/app/index.js:10:5)",
     );
     expect(exceptionEvent.properties.$exception_source).toBe("backend");
-    expect(exceptionEvent.properties.$session_id).toBe("ses_session456");
+    expectUUIDv7(exceptionEvent.properties.$session_id);
     expect(exceptionEvent.properties.resource_name).toBe("get_weather");
     expect(exceptionEvent.properties.tool_name).toBe("get_weather");
     expect(exceptionEvent.properties.server_name).toBe("weather-server");
@@ -450,7 +456,7 @@ describe("PostHogExporter", () => {
     expect(span.properties.$ai_is_error).toBe(false);
     expect(span.properties.$ai_input_state).toEqual({ city: "London" });
     expect(span.properties.$ai_output_state).toEqual({ temp: 15 });
-    expect(span.properties.$session_id).toBe("ses_session456");
+    expectUUIDv7(span.properties.$session_id);
     expect(span.properties.source).toBe("mcpcat");
     expect(span.properties.server_name).toBe("weather-server");
     expect(span.properties.client_name).toBe("claude-desktop");
@@ -498,11 +504,9 @@ describe("PostHogExporter", () => {
       spanA.properties.$ai_span_id,
     );
 
-    // Valid UUID format (8-4-4-4-12 with version=5 and variant=8-b)
-    const uuidRegex =
-      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-    expect(spanA.properties.$ai_trace_id).toMatch(uuidRegex);
-    expect(spanA.properties.$ai_span_id).toMatch(uuidRegex);
+    // Valid UUIDs (v5-format from toUUID)
+    expect(uuidValidate(spanA.properties.$ai_trace_id)).toBe(true);
+    expect(uuidValidate(spanA.properties.$ai_span_id)).toBe(true);
   });
 
   it("should NOT emit $ai_span when enableAITracing is false or unset", async () => {

--- a/src/tests/posthog-exporter.test.ts
+++ b/src/tests/posthog-exporter.test.ts
@@ -3,6 +3,7 @@ import { PostHogExporter } from "../modules/exporters/posthog.js";
 import { Event } from "../types.js";
 import { PublishEventRequestEventTypeEnum } from "mcpcat-api";
 import { validate as uuidValidate, version as uuidVersion } from "uuid";
+import KSUID from "../thirdparty/ksuid/index.js";
 
 function expectUUIDv7(value: string) {
   expect(uuidValidate(value)).toBe(true);
@@ -469,25 +470,30 @@ describe("PostHogExporter", () => {
       enableAITracing: true,
     });
 
-    // Export event A (evt_aaa, ses_xxx)
-    await exporter.export(makeEvent({ id: "evt_aaa", sessionId: "ses_xxx" }));
+    // Use real KSUIDs so toUUIDv7 can parse the embedded timestamp deterministically
+    const sesId = KSUID.withPrefix("ses").randomSync();
+    const evtA = KSUID.withPrefix("evt").randomSync();
+    const evtB = KSUID.withPrefix("evt").randomSync();
+
+    // Export event A
+    await exporter.export(makeEvent({ id: evtA, sessionId: sesId }));
     const bodyA = JSON.parse(fetchSpy.mock.calls[0][1].body);
     const spanA = bodyA.batch.find((e: any) => e.event === "$ai_span");
 
-    // Export event B (evt_bbb, ses_xxx) — same session, different event
+    // Export event B — same session, different event
     fetchSpy.mockClear();
-    await exporter.export(makeEvent({ id: "evt_bbb", sessionId: "ses_xxx" }));
+    await exporter.export(makeEvent({ id: evtB, sessionId: sesId }));
     const bodyB = JSON.parse(fetchSpy.mock.calls[0][1].body);
     const spanB = bodyB.batch.find((e: any) => e.event === "$ai_span");
 
     // Export event A again — verify determinism
     fetchSpy.mockClear();
-    await exporter.export(makeEvent({ id: "evt_aaa", sessionId: "ses_xxx" }));
+    await exporter.export(makeEvent({ id: evtA, sessionId: sesId }));
     const bodyC = JSON.parse(fetchSpy.mock.calls[0][1].body);
     const spanC = bodyC.batch.find((e: any) => e.event === "$ai_span");
 
     // Same sessionId → same $ai_session_id and $ai_trace_id
-    expect(spanA.properties.$ai_session_id).toBe("mcpcat_ses_xxx");
+    expect(spanA.properties.$ai_session_id).toBe(`mcpcat_${sesId}`);
     expect(spanA.properties.$ai_session_id).toBe(
       spanB.properties.$ai_session_id,
     );
@@ -504,9 +510,9 @@ describe("PostHogExporter", () => {
       spanA.properties.$ai_span_id,
     );
 
-    // Valid UUIDs (v5-format from toUUID)
-    expect(uuidValidate(spanA.properties.$ai_trace_id)).toBe(true);
-    expect(uuidValidate(spanA.properties.$ai_span_id)).toBe(true);
+    // Valid UUIDv7s
+    expectUUIDv7(spanA.properties.$ai_trace_id);
+    expectUUIDv7(spanA.properties.$ai_span_id);
   });
 
   it("should NOT emit $ai_span when enableAITracing is false or unset", async () => {

--- a/src/tests/posthog-uuidv7.test.ts
+++ b/src/tests/posthog-uuidv7.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { validate as uuidValidate, version as uuidVersion } from "uuid";
+import { toUUIDv7 } from "../modules/exporters/posthog.js";
+import KSUID from "../thirdparty/ksuid/index.js";
+
+describe("toUUIDv7", () => {
+  // Generate a real KSUID with ses_ prefix for realistic test data
+  const realSessionId = KSUID.withPrefix("ses").randomSync();
+
+  it("should produce a valid UUIDv7", () => {
+    const result = toUUIDv7(realSessionId);
+    expect(uuidValidate(result)).toBe(true);
+    expect(uuidVersion(result)).toBe(7);
+  });
+
+  it("should be deterministic — same input always produces same output", () => {
+    const a = toUUIDv7(realSessionId);
+    const b = toUUIDv7(realSessionId);
+    const c = toUUIDv7(realSessionId);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it("should produce different UUIDs for different session IDs", () => {
+    const sessionA = KSUID.withPrefix("ses").randomSync();
+    const sessionB = KSUID.withPrefix("ses").randomSync();
+    expect(toUUIDv7(sessionA)).not.toBe(toUUIDv7(sessionB));
+  });
+
+  it("should embed the KSUID timestamp in the UUIDv7", () => {
+    // Create a KSUID at a known time
+    const knownTime = new Date("2025-06-15T12:00:00Z").getTime();
+    const ksuid = KSUID.fromParts(knownTime, Buffer.alloc(16, 0xab));
+    const sessionId = `ses_${ksuid.string}`;
+
+    const result = toUUIDv7(sessionId);
+
+    // Extract timestamp from UUIDv7 (first 48 bits = first 12 hex chars)
+    const hex = result.replace(/-/g, "");
+    const extractedMs = parseInt(hex.substring(0, 12), 16);
+
+    // KSUID has second-level precision, so the extracted timestamp should
+    // be within 1 second of the known time
+    expect(Math.abs(extractedMs - knownTime)).toBeLessThan(1000);
+  });
+
+  it("should set version bits to 7 (0111)", () => {
+    const result = toUUIDv7(realSessionId);
+    // Version is the 13th hex character (index 14 in the formatted string, index 12 in raw hex)
+    const hex = result.replace(/-/g, "");
+    const versionNibble = parseInt(hex[12], 16);
+    expect(versionNibble).toBe(7);
+  });
+
+  it("should set variant bits to 10xx", () => {
+    const result = toUUIDv7(realSessionId);
+    // Variant is the 17th hex character (index 16 in raw hex)
+    const hex = result.replace(/-/g, "");
+    const variantNibble = parseInt(hex[16], 16);
+    // Must be 8, 9, a, or b (binary 10xx)
+    expect(variantNibble).toBeGreaterThanOrEqual(8);
+    expect(variantNibble).toBeLessThanOrEqual(0xb);
+  });
+
+  it("should handle evt_ prefix", () => {
+    const eventId = KSUID.withPrefix("evt").randomSync();
+    const result = toUUIDv7(eventId);
+    expect(uuidValidate(result)).toBe(true);
+    expect(uuidVersion(result)).toBe(7);
+  });
+
+  it("should handle invalid KSUID gracefully with fallback timestamp", () => {
+    const result = toUUIDv7("ses_invalid_ksuid_string");
+    // Should still produce a valid UUIDv7 (falls back to Date.now())
+    expect(uuidValidate(result)).toBe(true);
+    expect(uuidVersion(result)).toBe(7);
+  });
+
+  it("should produce timestamps that are before or equal to current time", () => {
+    const now = Date.now();
+    const result = toUUIDv7(realSessionId);
+
+    const hex = result.replace(/-/g, "");
+    const extractedMs = parseInt(hex.substring(0, 12), 16);
+
+    // KSUID creation time should be at or before now
+    expect(extractedMs).toBeLessThanOrEqual(now);
+  });
+});


### PR DESCRIPTION
## Summary

- **UUIDv7 `$session_id`**: PostHog requires `$session_id` to be a valid UUIDv7 for session aggregations. Previously we passed the raw MCPCat KSUID (`ses_abc123`) which meant events were excluded from session views. Now `toUUIDv7()` generates deterministic UUIDv7s by extracting the KSUID's embedded timestamp (satisfies PostHog's "timestamp must be at or before first event" requirement) and hashing the session ID for the random bits (ensures same session always maps to same UUID). Applies to all three event types: regular capture, `$exception`, and `$ai_span`.

- **Flat customer tags/properties**: Per PostHog team feedback (@rafaeelaudibert), removed `mcpcat_tag_` prefix and `mcpcat_properties` nesting from regular capture events. Customer tags and properties are now spread directly as top-level event properties on all PostHog events (regular + `$ai_span`), consistent behavior across both event types. `source: "mcpcat"` provides sufficient attribution.

- **`uuid` dev dependency**: Added for rigorous UUIDv7 validation in tests via `validate()` and `version()` rather than regex patterns.

## PostHog UUIDv7 requirements satisfied

| Requirement | How we satisfy it |
|---|---|
| Consistent across events in same session | Deterministic — same session KSUID always produces same UUIDv7 |
| Not reused by different user/session | KSUID is globally unique, hash is collision-resistant |
| Valid UUIDv7 | Version bits = 7, variant bits = 10, validated by `uuid` library in tests |
| Timestamp ≤ first event | Uses KSUID creation time, which predates any events in that session |
| Timestamp + 24h > last event | KSUID is created at session start; sessions timeout after 30min of inactivity |

## Test plan
- [ ] `pnpm test` — 433 tests passing (9 new UUIDv7 unit tests)
- [ ] `pnpm tsc --noEmit` — clean typecheck
- [ ] New `posthog-uuidv7.test.ts` validates: UUIDv7 format, determinism, uniqueness, timestamp embedding, version/variant bits, prefix handling, fallback for invalid KSUIDs
- [ ] Existing PostHog exporter tests updated to use `uuid` library validation instead of regex