### PR TITLE
fix: invoke identify hook on tools/list so events include identity

### DIFF
--- a/src/modules/tools.ts
+++ b/src/modules/tools.ts
@@ -4,7 +4,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { MCPServerLike, UnredactedEvent } from "../types.js";
 import { writeToLog } from "./logging.js";
-import { getServerTrackingData } from "./internal.js";
+import { getServerTrackingData, handleIdentify } from "./internal.js";
 import { addContextParameterToTools } from "./context-parameters.js";
 import { publishEvent } from "./eventQueue.js";
 import { getServerSessionId } from "./session.js";
@@ -74,6 +74,10 @@ export function setupMCPCatTools(server: MCPServerLike): void {
         timestamp: new Date(),
         redactionFn: data?.options.redactSensitiveInformation,
       };
+      if (data) {
+        await handleIdentify(server, data, request, extra);
+        event.sessionId = data.sessionId;
+      }
       try {
         const originalResponse = (await originalListToolsHandler(
           request,

--- a/src/modules/tracing.ts
+++ b/src/modules/tracing.ts
@@ -74,6 +74,8 @@ export function setupListToolsTracing(
         redactionFn: data?.options.redactSensitiveInformation,
       };
       if (data) {
+        await handleIdentify(server, data, request, extra);
+        event.sessionId = data.sessionId;
         const resolvedTags = await resolveEventTags(data, request, extra);
         if (resolvedTags) event.tags = resolvedTags;
         const resolvedProperties = await resolveEventProperties(

--- a/src/tests/identify.test.ts
+++ b/src/tests/identify.test.ts
@@ -4,7 +4,10 @@ import {
   resetTodos,
 } from "./test-utils/client-server-factory";
 import { track } from "../index";
-import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types";
+import {
+  CallToolResultSchema,
+  ListToolsResultSchema,
+} from "@modelcontextprotocol/sdk/types";
 import { EventCapture } from "./test-utils";
 import { PublishEventRequestEventTypeEnum } from "mcpcat-api";
 import { getServerTrackingData } from "../modules/internal";
@@ -744,6 +747,60 @@ describe("Identify Feature", () => {
       // It will store whatever was returned, even if invalid
       expect(storedIdentity).toBeDefined();
       expect((storedIdentity as any).invalidField).toBe("invalid");
+
+      await eventCapture.stop();
+    });
+  });
+
+  describe("Identify Fields on tools/list Events", () => {
+    it("should populate identify fields on mcp:tools/list event when tools/list is the first request after track()", async () => {
+      const eventCapture = new EventCapture();
+      await eventCapture.start();
+
+      let identifyCalled = false;
+      const testUserId = `list-tools-user-${randomUUID()}`;
+      const testUserName = `List Tools User ${randomUUID()}`;
+      const testUserData = {
+        plan: "premium",
+        org: `org-${randomUUID()}`,
+      };
+
+      track(server, "test-project", {
+        enableTracing: true,
+        identify: async () => {
+          identifyCalled = true;
+          return {
+            userId: testUserId,
+            userName: testUserName,
+            userData: testUserData,
+          };
+        },
+      });
+
+      // tools/list is the FIRST request after track() — no prior tools/call
+      // has had a chance to prime the identifiedSessions cache. The tools/list
+      // event should still publish with identify fields populated.
+      await client.request(
+        {
+          method: "tools/list",
+          params: {},
+        },
+        ListToolsResultSchema,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(identifyCalled).toBe(true);
+
+      const events = eventCapture.getEvents();
+      const listToolsEvent = events.find(
+        (e) => e.eventType === PublishEventRequestEventTypeEnum.mcpToolsList,
+      );
+
+      expect(listToolsEvent).toBeDefined();
+      expect(listToolsEvent?.identifyActorGivenId).toBe(testUserId);
+      expect(listToolsEvent?.identifyActorName).toBe(testUserName);
+      expect(listToolsEvent?.identifyActorData).toEqual(testUserData);
 
       await eventCapture.stop();
     });


### PR DESCRIPTION
## Summary

- The wrapped `tools/list` handlers in both the high-level path (`setupListToolsTracing` in `tracing.ts`) and the low-level path (`setupMCPCatTools` in `tools.ts`) never called `handleIdentify` before publishing. If `tools/list` was the first request in a session, the `identifiedSessions` cache was empty and the `mcp:tools/list` event published with `identifyActorGivenId`, `identifyActorName`, and `identifyActorData` unset — even when a fully functioning identify hook was configured.
- Align `tools/list` with `initialize` and `tools/call`: `await handleIdentify` after resolving tracking data, then publish. `getSessionInfo` backfills identity from the cache once it's populated.
- Adds a regression test under `Identify Fields on tools/list Events` that calls `tools/list` as the first request after `track()` and asserts the hook ran and all three identify fields land on the event.

## Test plan

- [x] New regression test fails on `main` (hook never fires for `tools/list`)
- [x] New regression test passes with the fix
- [x] `pnpm test` — 434 passed, 1 skipped, 0 failed
- [x] `pnpm typecheck` — clean