### PR TITLE
fix(tests): stop EventCapture from leaking real HTTP requests

### DIFF
--- a/src/tests/test-utils.ts
+++ b/src/tests/test-utils.ts
@@ -24,25 +24,33 @@ export const setupTestHooks = () => {
 export class EventCapture {
   private capturedEvents: Event[] = [];
   private originalEventQueueAdd?: (event: Event) => void;
+  private originalSendEvent?: (event: Event, retries?: number) => Promise<void>;
 
   async start() {
-    // Mock the eventQueue.add method to capture events
     const eventQueueModule = await import("../modules/eventQueue.js");
-    this.originalEventQueueAdd = eventQueueModule.eventQueue.add;
+    const eq = eventQueueModule.eventQueue as any;
+    this.originalEventQueueAdd = eq.add.bind(eq);
+    this.originalSendEvent = eq.sendEvent.bind(eq);
 
-    // Replace the add method with our capturing version
-    eventQueueModule.eventQueue.add = (event: Event) => {
+    // Capture at add() (synchronous) to keep this instance's events tied to
+    // this instance, then defer to the real add() so process() runs the
+    // redact/sanitize/truncate pipeline — those mutate the captured event in
+    // place via Object.assign. sendEvent is stubbed so no real HTTP goes out.
+    eq.add = (event: Event) => {
       this.capturedEvents.push(event);
-      // Still call the original if it exists (for integration tests)
-      this.originalEventQueueAdd?.call(eventQueueModule.eventQueue, event);
+      this.originalEventQueueAdd!(event);
     };
+    eq.sendEvent = async (_event: Event) => {};
   }
 
   async stop() {
-    // Restore the original method
-    if (this.originalEventQueueAdd) {
+    if (this.originalEventQueueAdd && this.originalSendEvent) {
       const eventQueueModule = await import("../modules/eventQueue.js");
-      eventQueueModule.eventQueue.add = this.originalEventQueueAdd;
+      const eq = eventQueueModule.eventQueue as any;
+      eq.add = this.originalEventQueueAdd;
+      eq.sendEvent = this.originalSendEvent;
+      this.originalEventQueueAdd = undefined;
+      this.originalSendEvent = undefined;
     }
   }
 


### PR DESCRIPTION
## What

`EventCapture` (the test helper used by ~13 test files) used to wrap `eventQueue.add` while still calling the original — so every captured event was also POSTed to `https://api.mcpcat.io` for real. CI runs and local `pnpm test` invocations have been generating live traffic to prod for months. Server-side, the events 4xx out at the worker (FK validation), so nothing landed in the DB, but the requests were real.

This PR plugs the network hole.

## How

`start()` now patches both:
- `eventQueue.add` — captures synchronously into `capturedEvents`, then defers to the real `add()` so `process()` still runs redact / sanitize / truncate (those mutate the captured event reference in place via `Object.assign`).
- `eventQueue.sendEvent` — stubbed to a no-op, severing the network call.

`stop()` restores both.

Why patch `add` synchronously rather than just `sendEvent`: `sendEvent` runs after an `await` chain in `process()`. If a test calls `stop()` before its publish callback has even reached `add()`, an event from one test could otherwise land in the next test's capture array. Capturing at `add()` keeps each instance's events scoped to that instance.

## Test plan

- [x] `pnpm test` — 433/434 pass, 1 preexisting skip (29/29 test files)
- [x] Spot-checked the post-processing assertion suites: `e2e-sanitization`, `e2e-truncation`, `redaction`, `error-capture`, `report-missing` all green