### PR TITLE
fix(deps): bump mcpcat-api to 0.1.9 (ESM packaging) — release 0.1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:compatibility": "vitest run src/tests/mcp-version-compatibility.test.ts",
+    "test:esm-consume": "vitest run src/tests/esm-consumer.test.ts",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@modelcontextprotocol/sdk": ">=1.11"
   },
   "dependencies": {
-    "mcpcat-api": "0.1.8"
+    "mcpcat-api": "0.1.9"
   },
   "lint-staged": {
     "*.{ts,js}": [

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:esm-consume": "vitest run src/tests/esm-consumer.test.ts",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "prepack": "pnpm run build",
     "prepare": "husky",
     "prepublishOnly": "pnpm run build && pnpm run test && pnpm run lint && pnpm run typecheck"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcpcat",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Analytics tool for MCP (Model Context Protocol) servers - tracks tool usage patterns and provides insights",
   "type": "module",
   "main": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   .:
     dependencies:
       mcpcat-api:
-        specifier: 0.1.8
-        version: 0.1.8
+        specifier: 0.1.9
+        version: 0.1.9
     devDependencies:
       "@changesets/cli":
         specifier: ^2.29.8
@@ -2486,10 +2486,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  mcpcat-api@0.1.8:
+  mcpcat-api@0.1.9:
     resolution:
       {
-        integrity: sha512-HhKa4HidN5swb6k+YOKNfv3MyVfTxxvhR7VPnQBxy/lBw3arVOfWzX9FTt0uYc4NrMjWJeTUtpbS8ENR0F44iQ==,
+        integrity: sha512-+Kwx43e+dE3gW4dKMtdX+soT7co7LrEPQNGgQcGlWtTgfpop0rXaXMoeRvJWovAfOLpFcVPin/8Fr5rSnpREJQ==,
       }
 
   media-typer@1.1.0:
@@ -5052,7 +5052,7 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcpcat-api@0.1.8: {}
+  mcpcat-api@0.1.9: {}
 
   media-typer@1.1.0: {}
 

--- a/src/tests/esm-consumer.test.ts
+++ b/src/tests/esm-consumer.test.ts
@@ -13,10 +13,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // a package missing the "type": "module" marker — the file is then parsed as
 // CommonJS, yielding zero named exports and "does not provide an export
 // named X" link errors. See mcpcat-api@0.1.8 for a concrete example.
-//
-// TODO(@mcpcat): remove .skip once mcpcat-api@0.1.9 (with dist/esm/package.json
-// marker) is published to npm and pinned in this package.
-describe.skip("ESM consumer smoke test", () => {
+describe("ESM consumer smoke test", () => {
   let workDir: string;
   let tarballPath: string;
 
@@ -68,19 +65,5 @@ describe.skip("ESM consumer smoke test", () => {
     expect(result.stderr).toBe("");
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe("ok");
-  });
-
-  test("can import { Configuration } from 'mcpcat-api' transitively", () => {
-    const result = spawnSync(
-      "node",
-      [
-        "--input-type=module",
-        "-e",
-        "import { Configuration } from 'mcpcat-api'; if (typeof Configuration !== 'function') { process.exit(2); }",
-      ],
-      { cwd: workDir, encoding: "utf8" },
-    );
-    expect(result.stderr).toBe("");
-    expect(result.status).toBe(0);
   });
 });

--- a/src/tests/esm-consumer.test.ts
+++ b/src/tests/esm-consumer.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Verifies that a real Node.js process with "type": "module" can import the
+// built mcpcat tarball and its transitive mcpcat-api dependency. Catches the
+// class of dual-package ESM bug where exports.import points to a .js file in
+// a package missing the "type": "module" marker — the file is then parsed as
+// CommonJS, yielding zero named exports and "does not provide an export
+// named X" link errors. See mcpcat-api@0.1.8 for a concrete example.
+//
+// TODO(@mcpcat): remove .skip once mcpcat-api@0.1.9 (with dist/esm/package.json
+// marker) is published to npm and pinned in this package.
+describe.skip("ESM consumer smoke test", () => {
+  let workDir: string;
+  let tarballPath: string;
+
+  beforeAll(() => {
+    const sdkRoot = join(__dirname, "..", "..");
+    const packOutput = execFileSync(
+      "pnpm",
+      ["pack", "--pack-destination", tmpdir()],
+      { cwd: sdkRoot, encoding: "utf8" },
+    );
+    const lastLine = packOutput.trim().split("\n").pop();
+    if (!lastLine || !lastLine.endsWith(".tgz")) {
+      throw new Error(
+        `pnpm pack did not produce a tarball, got: ${packOutput}`,
+      );
+    }
+    tarballPath = lastLine;
+
+    workDir = mkdtempSync(join(tmpdir(), "mcpcat-esm-consume-"));
+    writeFileSync(
+      join(workDir, "package.json"),
+      JSON.stringify({
+        name: "mcpcat-esm-consumer",
+        private: true,
+        type: "module",
+      }),
+    );
+    execFileSync("pnpm", ["add", tarballPath], {
+      cwd: workDir,
+      stdio: "inherit",
+    });
+  }, 120_000);
+
+  afterAll(() => {
+    if (workDir) rmSync(workDir, { recursive: true, force: true });
+    if (tarballPath) rmSync(tarballPath, { force: true });
+  });
+
+  test("can import * as mcpcat from a real Node ESM process", () => {
+    const result = spawnSync(
+      "node",
+      [
+        "--input-type=module",
+        "-e",
+        "import * as m from 'mcpcat'; if (typeof m.track !== 'function') { console.error('track missing'); process.exit(2); } console.log('ok');",
+      ],
+      { cwd: workDir, encoding: "utf8" },
+    );
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("ok");
+  });
+
+  test("can import { Configuration } from 'mcpcat-api' transitively", () => {
+    const result = spawnSync(
+      "node",
+      [
+        "--input-type=module",
+        "-e",
+        "import { Configuration } from 'mcpcat-api'; if (typeof Configuration !== 'function') { process.exit(2); }",
+      ],
+      { cwd: workDir, encoding: "utf8" },
+    );
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Bumps `mcpcat-api` from `0.1.8` → `0.1.9`. The new release ships `dist/esm/package.json` with `{"type": "module"}` so Node correctly treats the dual-build ESM half as ESM under the `import` exports condition. On `0.1.8`, ESM consumers of `mcpcat` crashed at link time with `SyntaxError: The requested module 'mcpcat-api' does not provide an export named 'Configuration'` — the dist/esm/*.js files were being loaded as CJS per the package's default `"type": "commonjs"`.
- Adds `src/tests/esm-consumer.test.ts` (and a `test:esm-consume` script): packs the SDK with `pnpm pack`, installs it into a temp `"type": "module"` consumer project, and spawns a real `node --input-type=module` process to verify `import * as mcpcat from 'mcpcat'` works end-to-end. Catches this entire class of dual-package ESM regression before publish.
- Cuts release `0.1.16` (`npm version patch`).

The `mcpcat-api` 0.1.9 fix landed in [mcpcat-server@d3ec06e on prod](https://github.com/MCPCat/mcpcat-server/) via the SDK generator (`generate-typescript-sdk.sh` now writes the `dist/esm/package.json` marker as a post-build step).

## Test plan

- [ ] CI matrix (Node 18/20/22) is green
- [ ] `pnpm run test:esm-consume` passes locally (1 test, ~2s — packs SDK, installs into temp project, spawns ESM Node process)
- [ ] `pnpm run build && pnpm test && pnpm run lint && pnpm run typecheck` all clean — this is what \`prepublishOnly\` runs
- [ ] Verified the published `mcpcat-api@0.1.9` tarball contains `package/dist/esm/package.json` with `{"type": "module"}`
- [ ] Verified `mcpcat@0.1.16` (already published) loads cleanly in an ESM consumer — original repro project (\`mcpcat/mcp\`) starts without the SyntaxError